### PR TITLE
feat: ultralight inspector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ instructions/
 # files
 *.zip
 compile_commands.json
+/release

--- a/src/API/API.cpp
+++ b/src/API/API.cpp
@@ -176,3 +176,35 @@ int PluginAPI::PrismaUIInterface::GetOrder(PrismaView view) noexcept
 	}
 	return PrismaUI::ViewManager::GetOrder(view);
 }
+
+void PluginAPI::PrismaUIInterface::CreateInspectorView(PrismaView view) noexcept
+{
+    if (!view) {
+        return;
+    }
+    return PrismaUI::ViewManager::CreateInspectorView(view);
+}
+
+void PluginAPI::PrismaUIInterface::SetInspectorVisibility(PrismaView view, bool visible) noexcept
+{
+    if (!view) {
+        return;
+    }
+    return PrismaUI::ViewManager::SetInspectorVisibility(view, visible);
+}
+
+bool PluginAPI::PrismaUIInterface::IsInspectorVisible(PrismaView view) noexcept
+{
+    if (!view) {
+        return false;
+    }
+    return PrismaUI::ViewManager::IsInspectorVisible(view);
+}
+
+void PluginAPI::PrismaUIInterface::SetInspectorBounds(PrismaView view, float topLeftX, float topLeftY, unsigned int width, unsigned int height) noexcept
+{
+    if (!view) {
+        return;
+    }
+    return PrismaUI::ViewManager::SetInspectorBounds(view, topLeftX, topLeftY, width, height);
+}

--- a/src/API/API.h
+++ b/src/API/API.h
@@ -39,6 +39,12 @@ public:
 		virtual void SetOrder(PrismaView view, int order) noexcept override;
 		virtual int GetOrder(PrismaView view) noexcept override;
 
+		// Inspector methods
+		virtual void CreateInspectorView(PrismaView view) noexcept override;
+		virtual void SetInspectorVisibility(PrismaView view, bool visible) noexcept override;
+		virtual bool IsInspectorVisible(PrismaView view) noexcept override;
+		virtual void SetInspectorBounds(PrismaView view, float topLeftX, float topLeftY, unsigned int width, unsigned int height) noexcept override;
+
 	private:
 		unsigned long apiTID = 0;
 	};

--- a/src/PrismaUI/Core.cpp
+++ b/src/PrismaUI/Core.cpp
@@ -5,6 +5,7 @@
 #include "InputHandler.h"
 #include "Communication.h"
 #include "ViewOperationQueue.h"
+#include "Inspector.h"
 
 namespace PrismaUI::Core {
 	using namespace PrismaUI::Listeners;
@@ -184,6 +185,7 @@ namespace PrismaUI::Core {
 			if (viewData) {
 				logger::debug("D3DPresent: Releasing D3D resources for View [{}] from render thread", viewId);
 				ViewRenderer::ReleaseViewTexture(viewData.get());
+				Inspector::ReleaseInspectorTexture(viewData.get());
 				viewData->pendingResourceRelease = false;
 			}
 		}

--- a/src/PrismaUI/Core.h
+++ b/src/PrismaUI/Core.h
@@ -46,6 +46,7 @@ namespace PrismaUI::Core {
 	struct PrismaView {
 		PrismaViewId id;
 		RefPtr<View> ultralightView = nullptr;
+		RefPtr<View> inspectorView = nullptr;
 		std::string htmlPathToLoad;
 		std::atomic<bool> isHidden = false;
 		std::unique_ptr<Listeners::MyLoadListener> loadListener;
@@ -55,7 +56,27 @@ namespace PrismaUI::Core {
 		int scrollingPixelSize = 28;
 		std::atomic<bool> isPaused = false;
 		int order = 0;
+		std::atomic<bool> inspectorVisible = false;
 
+		// Inspector rendering data
+		std::vector<std::byte> inspectorPixelBuffer;
+		uint32_t inspectorBufferWidth = 0;
+		uint32_t inspectorBufferHeight = 0;
+		uint32_t inspectorBufferStride = 0;
+		std::mutex inspectorBufferMutex;
+		std::atomic<bool> inspectorFrameReady = false;
+		std::atomic<bool> inspectorPointerHover = false;
+		ID3D11Texture2D* inspectorTexture = nullptr;
+		ID3D11ShaderResourceView* inspectorTextureView = nullptr;
+		uint32_t inspectorTextureWidth = 0;
+		uint32_t inspectorTextureHeight = 0;
+		float inspectorPosX = 0.0f;
+		float inspectorPosY = 0.0f;
+		uint32_t inspectorDisplayWidth = 0;
+		uint32_t inspectorDisplayHeight = 0;
+		float inspectorOpacity = 1.0f;
+
+		// Primary view rendering data
 		ID3D11Texture2D* texture = nullptr;
 		ID3D11ShaderResourceView* textureView = nullptr;
 		uint32_t textureWidth = 0;
@@ -113,4 +134,10 @@ namespace PrismaUI::Core {
 	void InitGraphics();
 	void D3DPresent(uint32_t a_p1);
 	void Shutdown();
+
+	// Inspector View functions
+	void CreateInspectorView(const PrismaViewId& viewId);
+	void SetInspectorVisibility(const PrismaViewId& viewId, bool visible);
+	bool IsInspectorVisible(const PrismaViewId& viewId);
+	void SetInspectorBounds(const PrismaViewId& viewId, float topLeftX, float topLeftY, uint32_t width, uint32_t height);
 }

--- a/src/PrismaUI/Inspector.cpp
+++ b/src/PrismaUI/Inspector.cpp
@@ -1,0 +1,399 @@
+#include "Inspector.h"
+#include "Core.h"
+#include "ViewManager.h"
+
+#include <algorithm>
+#include <cmath>
+#include <filesystem>
+#include <cstring>
+
+#ifdef min
+#undef min
+#endif
+#ifdef max
+#undef max
+#endif
+
+namespace PrismaUI::Inspector {
+	using namespace Core;
+
+	namespace {
+		std::once_flag gInspectorAssetCheckFlag;
+		std::atomic<bool> gInspectorAssetsAvailable{ false };
+	}
+
+	// ========== Asset Management ==========
+
+	void EnsureInspectorAssetsAvailability()
+	{
+		std::call_once(gInspectorAssetCheckFlag, []() {
+			try {
+				const auto inspectorPath = std::filesystem::current_path() / "inspector" / "Main.html";
+				if (std::filesystem::exists(inspectorPath)) {
+					gInspectorAssetsAvailable.store(true);
+					logger::info("Ultralight inspector assets detected at {}", inspectorPath.string());
+				}
+				else {
+					logger::warn("Ultralight inspector assets were not found at {}. Inspector view will not render unless the SDK inspector folder is copied next to the DLL.", inspectorPath.string());
+				}
+			}
+			catch (const std::exception& e) {
+				logger::warn("Failed to verify Ultralight inspector asset directory: {}", e.what());
+			}
+		});
+	}
+
+	bool AreInspectorAssetsAvailable()
+	{
+		EnsureInspectorAssetsAvailability();
+		return gInspectorAssetsAvailable.load();
+	}
+
+	// ========== Resource Management ==========
+
+	void ReleaseInspectorTexture(PrismaView* viewData)
+	{
+		if (!viewData) {
+			return;
+		}
+
+		if (viewData->inspectorTextureView) {
+			viewData->inspectorTextureView->Release();
+			viewData->inspectorTextureView = nullptr;
+		}
+
+		if (viewData->inspectorTexture) {
+			viewData->inspectorTexture->Release();
+			viewData->inspectorTexture = nullptr;
+		}
+
+		viewData->inspectorTextureWidth = 0;
+		viewData->inspectorTextureHeight = 0;
+	}
+
+	void DestroyInspectorResources(PrismaView* viewData)
+	{
+		if (!viewData) {
+			return;
+		}
+
+		ReleaseInspectorTexture(viewData);
+
+		{
+			std::lock_guard bufferLock(viewData->inspectorBufferMutex);
+			viewData->inspectorPixelBuffer.clear();
+			viewData->inspectorPixelBuffer.shrink_to_fit();
+			viewData->inspectorBufferWidth = 0;
+			viewData->inspectorBufferHeight = 0;
+			viewData->inspectorBufferStride = 0;
+		}
+
+		viewData->inspectorFrameReady.store(false);
+		viewData->inspectorPointerHover.store(false);
+	}
+
+	// ========== Inspector Lifecycle ==========
+
+	void CreateInspectorView(const PrismaViewId& viewId)
+	{
+		EnsureInspectorAssetsAvailability();
+		if (!gInspectorAssetsAvailable.load()) {
+			logger::warn("View [{}]: Inspector assets were not found. Copy the Ultralight inspector folder next to PrismaUI.dll to enable the inspector.", viewId);
+			return;
+		}
+
+		std::shared_ptr<PrismaView> viewData = nullptr;
+		{
+			std::shared_lock lock(viewsMutex);
+			auto it = views.find(viewId);
+			if (it != views.end()) {
+				viewData = it->second;
+			}
+		}
+
+		if (!viewData) {
+			logger::warn("CreateInspectorView: View ID [{}] not found.", viewId);
+			return;
+		}
+
+		if (viewData->inspectorView) {
+			logger::info("View [{}]: Inspector view already exists.", viewId);
+			return;
+		}
+
+		if (!viewData->ultralightView) {
+			logger::warn("View [{}]: Cannot create inspector because Ultralight view is not ready yet.", viewId);
+			return;
+		}
+
+		try {
+			auto createInspector = [view = viewData]() {
+				if (view->ultralightView) {
+					view->ultralightView->CreateLocalInspectorView();
+				}
+			};
+
+			if (ultralightThread.IsWorkerThread()) {
+				createInspector();
+			}
+			else {
+				auto future = ultralightThread.submit_with_priority(SingleThreadExecutor::Priority::MEDIUM, createInspector);
+				future.get();
+			}
+			logger::info("View [{}]: Inspector creation requested.", viewId);
+		}
+		catch (const std::exception& e) {
+			logger::error("View [{}]: Exception while creating inspector view: {}", viewId, e.what());
+		}
+	}
+
+	void SetInspectorVisibility(const PrismaViewId& viewId, bool visible)
+	{
+		std::shared_ptr<PrismaView> viewData = nullptr;
+		{
+			std::shared_lock lock(viewsMutex);
+			auto it = views.find(viewId);
+			if (it != views.end()) {
+				viewData = it->second;
+			}
+		}
+
+		if (!viewData) {
+			logger::warn("SetInspectorVisibility: View ID [{}] not found.", viewId);
+			return;
+		}
+
+		if (!viewData->inspectorView && visible) {
+			CreateInspectorView(viewId);
+		}
+
+		if (!viewData->inspectorView) {
+			logger::warn("View [{}]: Inspector view is not available to {}.", viewId, visible ? "show" : "hide");
+			return;
+		}
+
+		viewData->inspectorVisible.store(visible);
+		viewData->inspectorPointerHover.store(false);
+
+		if (visible && viewData->ultralightView && ViewManager::HasFocus(viewId)) {
+			auto future = ultralightThread.submit_with_priority(SingleThreadExecutor::Priority::MEDIUM, [view = viewData]() {
+				if (view->inspectorView) {
+					view->inspectorView->Focus();
+				}
+				if (view->ultralightView) {
+					view->ultralightView->Unfocus();
+				}
+			});
+			future.wait();
+		}
+
+		logger::info("View [{}]: Inspector visibility set to {}.", viewId, visible);
+	}
+
+	bool IsInspectorVisible(const PrismaViewId& viewId)
+	{
+		std::shared_lock lock(viewsMutex);
+		auto it = views.find(viewId);
+		if (it != views.end() && it->second) {
+			return it->second->inspectorVisible.load();
+		}
+		return false;
+	}
+
+	void SetInspectorBounds(const PrismaViewId& viewId, float topLeftX, float topLeftY, uint32_t width, uint32_t height)
+	{
+		width = std::max<uint32_t>(width, 32u);
+		height = std::max<uint32_t>(height, 32u);
+
+		std::shared_ptr<PrismaView> viewData = nullptr;
+		{
+			std::shared_lock lock(viewsMutex);
+			auto it = views.find(viewId);
+			if (it != views.end()) {
+				viewData = it->second;
+			}
+		}
+
+		if (!viewData) {
+			logger::warn("SetInspectorBounds: View ID [{}] not found.", viewId);
+			return;
+		}
+
+		if (!viewData->inspectorView) {
+			logger::warn("View [{}]: Cannot set inspector bounds because inspector is not available.", viewId);
+			return;
+		}
+
+		const float screenW = static_cast<float>(screenSize.width ? screenSize.width : width);
+		const float screenH = static_cast<float>(screenSize.height ? screenSize.height : height);
+		const float maxX = std::max(0.0f, screenW - static_cast<float>(width));
+		const float maxY = std::max(0.0f, screenH - static_cast<float>(height));
+
+		viewData->inspectorPosX = std::clamp(topLeftX, 0.0f, maxX);
+		viewData->inspectorPosY = std::clamp(topLeftY, 0.0f, maxY);
+		viewData->inspectorDisplayWidth = width;
+		viewData->inspectorDisplayHeight = height;
+		viewData->inspectorPointerHover.store(false);
+
+		try {
+			auto resizeInspector = [view = viewData, width, height]() {
+				if (view->inspectorView) {
+					view->inspectorView->Resize(width, height);
+				}
+			};
+
+			if (ultralightThread.IsWorkerThread()) {
+				resizeInspector();
+			}
+			else {
+				auto future = ultralightThread.submit_with_priority(SingleThreadExecutor::Priority::MEDIUM, resizeInspector);
+				future.wait();
+			}
+			logger::info("View [{}]: Inspector bounds set to ({}, {}) with size {}x{}", viewId, topLeftX, topLeftY, width, height);
+		}
+		catch (const std::exception& e) {
+			logger::error("View [{}]: Exception while setting inspector bounds: {}", viewId, e.what());
+		}
+	}
+
+	// ========== Rendering Pipeline ==========
+
+	void RenderInspectorView(std::shared_ptr<PrismaView> viewData)
+	{
+		if (!viewData || !viewData->inspectorView || !viewData->inspectorVisible.load() || viewData->isHidden.load()) {
+			return;
+		}
+
+		Surface* surface = viewData->inspectorView->surface();
+		if (surface) {
+			CopyInspectorBitmapToBuffer(viewData);
+		}
+	}
+
+	void CopyInspectorBitmapToBuffer(std::shared_ptr<PrismaView> viewData)
+	{
+		if (!viewData || !viewData->inspectorView) {
+			return;
+		}
+
+		Surface* surface = viewData->inspectorView->surface();
+		if (!surface) {
+			return;
+		}
+
+		// For inspector views, try BitmapSurface
+		BitmapSurface* bitmapSurface = static_cast<BitmapSurface*>(surface);
+		if (!bitmapSurface) {
+			return;
+		}
+
+		RefPtr<Bitmap> bitmap = bitmapSurface->bitmap();
+		if (!bitmap || bitmap->IsEmpty()) {
+			return;
+		}
+
+		const void* pixels = bitmap->LockPixels();
+		if (!pixels) {
+			bitmap->UnlockPixels();
+			return;
+		}
+
+		const uint32_t width = bitmap->width();
+		const uint32_t height = bitmap->height();
+		const uint32_t stride = bitmap->row_bytes();
+		const size_t dataSize = stride * height;
+
+		{
+			std::lock_guard<std::mutex> lock(viewData->inspectorBufferMutex);
+
+			if (viewData->inspectorPixelBuffer.size() != dataSize) {
+				viewData->inspectorPixelBuffer.resize(dataSize);
+			}
+
+			std::memcpy(viewData->inspectorPixelBuffer.data(), pixels, dataSize);
+
+			viewData->inspectorBufferWidth = width;
+			viewData->inspectorBufferHeight = height;
+			viewData->inspectorBufferStride = stride;
+			viewData->inspectorFrameReady.store(true);
+		}
+
+		bitmap->UnlockPixels();
+	}
+
+	void CopyInspectorPixelsToTexture(PrismaView* viewData, void* pixels, uint32_t width, uint32_t height, uint32_t stride)
+	{
+		if (!viewData || !pixels || !d3dContext || !d3dDevice) {
+			return;
+		}
+
+		if (width == 0 || height == 0) {
+			return;
+		}
+
+		// Recreate texture if size changed
+		if (!viewData->inspectorTexture ||
+			viewData->inspectorTextureWidth != width ||
+			viewData->inspectorTextureHeight != height) {
+
+			if (viewData->inspectorTextureView) {
+				viewData->inspectorTextureView->Release();
+				viewData->inspectorTextureView = nullptr;
+			}
+			if (viewData->inspectorTexture) {
+				viewData->inspectorTexture->Release();
+				viewData->inspectorTexture = nullptr;
+			}
+
+			D3D11_TEXTURE2D_DESC texDesc = {};
+			texDesc.Width = width;
+			texDesc.Height = height;
+			texDesc.MipLevels = 1;
+			texDesc.ArraySize = 1;
+			texDesc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+			texDesc.SampleDesc.Count = 1;
+			texDesc.Usage = D3D11_USAGE_DYNAMIC;
+			texDesc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+			texDesc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+
+			HRESULT hr = d3dDevice->CreateTexture2D(&texDesc, nullptr, &viewData->inspectorTexture);
+			if (FAILED(hr)) {
+				logger::error("Failed to create inspector D3D11 texture for View [{}]: HRESULT={:X}", viewData->id, static_cast<unsigned>(hr));
+				return;
+			}
+
+			D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+			srvDesc.Format = texDesc.Format;
+			srvDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+			srvDesc.Texture2D.MipLevels = 1;
+
+			hr = d3dDevice->CreateShaderResourceView(viewData->inspectorTexture, &srvDesc, &viewData->inspectorTextureView);
+			if (FAILED(hr)) {
+				logger::error("Failed to create inspector shader resource view for View [{}]: HRESULT={:X}", viewData->id, static_cast<unsigned>(hr));
+				viewData->inspectorTexture->Release();
+				viewData->inspectorTexture = nullptr;
+				return;
+			}
+
+			viewData->inspectorTextureWidth = width;
+			viewData->inspectorTextureHeight = height;
+		}
+
+		// Upload pixels to texture
+		D3D11_MAPPED_SUBRESOURCE mapped;
+		HRESULT hr = d3dContext->Map(viewData->inspectorTexture, 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped);
+		if (SUCCEEDED(hr)) {
+			const uint8_t* src = static_cast<const uint8_t*>(pixels);
+			uint8_t* dst = static_cast<uint8_t*>(mapped.pData);
+
+			for (uint32_t row = 0; row < height; ++row) {
+				std::memcpy(dst + row * mapped.RowPitch, src + row * stride, width * 4);
+			}
+
+			d3dContext->Unmap(viewData->inspectorTexture, 0);
+		}
+		else {
+			logger::error("Failed to map inspector texture for View [{}]: HRESULT={:X}", viewData->id, static_cast<unsigned>(hr));
+		}
+	}
+}

--- a/src/PrismaUI/Inspector.cpp
+++ b/src/PrismaUI/Inspector.cpp
@@ -15,6 +15,8 @@
 #endif
 
 namespace PrismaUI::Inspector {
+	// BGRA pixel format constant
+	constexpr uint32_t BYTES_PER_PIXEL = 4;
 	using namespace Core;
 
 	namespace {
@@ -175,12 +177,13 @@ namespace PrismaUI::Inspector {
 		viewData->inspectorVisible.store(visible);
 		viewData->inspectorPointerHover.store(false);
 
-		if (visible && viewData->ultralightView && ViewManager::HasFocus(viewId)) {
+		if (visible && viewData->inspectorView) {
+			// Focus the inspector view when made visible
 			auto future = ultralightThread.submit_with_priority(SingleThreadExecutor::Priority::MEDIUM, [view = viewData]() {
 				if (view->inspectorView) {
 					view->inspectorView->Focus();
 				}
-				if (view->ultralightView) {
+				if (view->ultralightView && view->ultralightView->HasFocus()) {
 					view->ultralightView->Unfocus();
 				}
 			});
@@ -387,7 +390,7 @@ namespace PrismaUI::Inspector {
 			uint8_t* dst = static_cast<uint8_t*>(mapped.pData);
 
 			for (uint32_t row = 0; row < height; ++row) {
-				std::memcpy(dst + row * mapped.RowPitch, src + row * stride, width * 4);
+				std::memcpy(dst + row * mapped.RowPitch, src + row * stride, width * BYTES_PER_PIXEL);
 			}
 
 			d3dContext->Unmap(viewData->inspectorTexture, 0);

--- a/src/PrismaUI/Inspector.h
+++ b/src/PrismaUI/Inspector.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <Ultralight/Ultralight.h>
+#include <Ultralight/View.h>
+#include <memory>
+
+namespace PrismaUI::Core {
+	typedef uint64_t PrismaViewId;
+	struct PrismaView;
+}
+
+namespace PrismaUI::Inspector {
+	using namespace ultralight;
+
+	// Inspector lifecycle management
+	void CreateInspectorView(const Core::PrismaViewId& viewId);
+	void SetInspectorVisibility(const Core::PrismaViewId& viewId, bool visible);
+	bool IsInspectorVisible(const Core::PrismaViewId& viewId);
+	void SetInspectorBounds(const Core::PrismaViewId& viewId, float topLeftX, float topLeftY, uint32_t width, uint32_t height);
+
+	// Inspector rendering (called from ViewRenderer)
+	void RenderInspectorView(std::shared_ptr<Core::PrismaView> viewData);
+	void CopyInspectorBitmapToBuffer(std::shared_ptr<Core::PrismaView> viewData);
+	void CopyInspectorPixelsToTexture(Core::PrismaView* viewData, void* pixels, uint32_t width, uint32_t height, uint32_t stride);
+
+	// Inspector resource management
+	void ReleaseInspectorTexture(Core::PrismaView* viewData);
+	void DestroyInspectorResources(Core::PrismaView* viewData);
+
+	// Inspector utilities
+	void EnsureInspectorAssetsAvailability();
+	bool AreInspectorAssetsAvailable();
+}

--- a/src/PrismaUI/Listeners.cpp
+++ b/src/PrismaUI/Listeners.cpp
@@ -69,6 +69,39 @@ namespace PrismaUI::Listeners {
 		logger::info("View [{}]: JSConsole: {}", viewId_, message.message().utf8().data());
 	}
 
+	RefPtr<View> MyViewListener::OnCreateInspectorView(View* caller, bool is_local, const String& inspectedURL) {
+		logger::info("View [{}]: ViewListener: OnCreateInspectorView called (is_local={}, URL={})", 
+			viewId_, is_local, inspectedURL.utf8().data());
+
+		RefPtr<View> inspectorView = nullptr;
+
+		std::shared_lock lock(viewsMutex);
+		auto it = views.find(viewId_);
+		if (it != views.end() && it->second) {
+			auto viewData = it->second;
+
+			if (!viewData->inspectorView && viewData->ultralightView && renderer) {
+				uint32_t width = viewData->inspectorDisplayWidth > 0 ? viewData->inspectorDisplayWidth : 800;
+				uint32_t height = viewData->inspectorDisplayHeight > 0 ? viewData->inspectorDisplayHeight : 600;
+
+				ViewConfig config;
+				config.is_accelerated = false;
+				config.is_transparent = true;
+
+				viewData->inspectorView = renderer->CreateView(width, height, config, nullptr);
+				inspectorView = viewData->inspectorView;
+
+				logger::info("View [{}]: Inspector view created with size {}x{}", viewId_, width, height);
+			}
+			else if (viewData->inspectorView) {
+				inspectorView = viewData->inspectorView;
+				logger::info("View [{}]: Returning existing inspector view", viewId_);
+			}
+		}
+
+		return inspectorView;
+	}
+
 	// MyUltralightLogger
 	MyUltralightLogger::~MyUltralightLogger() = default;
 

--- a/src/PrismaUI/Listeners.h
+++ b/src/PrismaUI/Listeners.h
@@ -35,6 +35,7 @@ namespace PrismaUI::Listeners {
 		virtual ~MyViewListener();
 
 		virtual void OnAddConsoleMessage(View* caller, const ConsoleMessage& message) override;
+		virtual RefPtr<View> OnCreateInspectorView(View* caller, bool is_local, const String& inspectedURL) override;
 	};
 
 	class MyUltralightLogger : public Logger {

--- a/src/PrismaUI/ViewManager.cpp
+++ b/src/PrismaUI/ViewManager.cpp
@@ -3,6 +3,7 @@
 #include "InputHandler.h"
 #include "Listeners.h"
 #include "ViewOperationQueue.h"
+#include "Inspector.h"
 
 namespace PrismaUI::ViewManager {
 	using namespace Core;
@@ -451,6 +452,13 @@ namespace PrismaUI::ViewManager {
 			try {
 				logger::debug("Destroy: Beginning Ultralight resources cleanup for View [{}]", viewId);
 
+				// Clean up inspector resources first
+				if (viewData->inspectorView) {
+					logger::debug("Destroy: Releasing inspector view for View [{}]", viewId);
+					viewData->inspectorView = nullptr;
+				}
+				Inspector::DestroyInspectorResources(viewData.get());
+
 				if (viewData->ultralightView) {
 					logger::debug("Destroy: Detaching listeners for View [{}]", viewId);
 					viewData->ultralightView->set_load_listener(nullptr);
@@ -554,5 +562,23 @@ namespace PrismaUI::ViewManager {
 		}
 		logger::warn("GetOrder: View ID [{}] not found, returning -1.", viewId);
 		return -1;
+	}
+
+	// ========== Inspector API Wrappers ==========
+
+	void CreateInspectorView(const Core::PrismaViewId& viewId) {
+		Inspector::CreateInspectorView(viewId);
+	}
+
+	void SetInspectorVisibility(const Core::PrismaViewId& viewId, bool visible) {
+		Inspector::SetInspectorVisibility(viewId, visible);
+	}
+
+	bool IsInspectorVisible(const Core::PrismaViewId& viewId) {
+		return Inspector::IsInspectorVisible(viewId);
+	}
+
+	void SetInspectorBounds(const Core::PrismaViewId& viewId, float topLeftX, float topLeftY, uint32_t width, uint32_t height) {
+		Inspector::SetInspectorBounds(viewId, topLeftX, topLeftY, width, height);
 	}
 }

--- a/src/PrismaUI/ViewManager.h
+++ b/src/PrismaUI/ViewManager.h
@@ -27,4 +27,10 @@ namespace PrismaUI::ViewManager {
 	int GetScrollingPixelSize(const Core::PrismaViewId& viewId);
 	void SetOrder(const Core::PrismaViewId& viewId, int order);
 	int GetOrder(const Core::PrismaViewId& viewId);
+
+	// Inspector View functions
+	void CreateInspectorView(const Core::PrismaViewId& viewId);
+	void SetInspectorVisibility(const Core::PrismaViewId& viewId, bool visible);
+	bool IsInspectorVisible(const Core::PrismaViewId& viewId);
+	void SetInspectorBounds(const Core::PrismaViewId& viewId, float topLeftX, float topLeftY, uint32_t width, uint32_t height);
 }

--- a/src/PrismaUI_API.h
+++ b/src/PrismaUI_API.h
@@ -77,6 +77,18 @@ namespace PRISMA_UI_API
 
 		// Get view order.
 		virtual int GetOrder(PrismaView view) noexcept = 0;
+
+		// Create inspector view for debugging.
+		virtual void CreateInspectorView(PrismaView view) noexcept = 0;
+
+		// Show or hide the inspector overlay.
+		virtual void SetInspectorVisibility(PrismaView view, bool visible) noexcept = 0;
+
+		// Returns true if inspector is visible.
+		virtual bool IsInspectorVisible(PrismaView view) noexcept = 0;
+
+		// Set inspector window position and size.
+		virtual void SetInspectorBounds(PrismaView view, float topLeftX, float topLeftY, unsigned int width, unsigned int height) noexcept = 0;
 	};
 
 	typedef void* (*_RequestPluginAPI)(const InterfaceVersion interfaceVersion);

--- a/xmake-requires.lock
+++ b/xmake-requires.lock
@@ -9,7 +9,7 @@
                 commit = "2111b79aae54ba2bdbf6b39a9fe5b6bec116b527",
                 url = "https://github.com/xmake-io/xmake-repo.git"
             },
-            version = "4.0.0-rc1"
+            version = "3.31.1"
         },
         ["directxmath#31fecfc4"] = {
             repo = {
@@ -38,7 +38,7 @@
         ["rapidcsv#31fecfc4"] = {
             repo = {
                 branch = "master",
-                commit = "af7eae5a80b40e382927170080b54e0f258f7a27",
+                commit = "873a175d3945b4080ab884a292b9351723337666",
                 url = "https://github.com/xmake-io/xmake-repo.git"
             },
             version = "v8.87"
@@ -46,7 +46,7 @@
         ["spdlog#9c36f0a9"] = {
             repo = {
                 branch = "master",
-                commit = "3df5cf899dd47cf780633d7e74d805a289e1d6c6",
+                commit = "873a175d3945b4080ab884a292b9351723337666",
                 url = "https://github.com/xmake-io/xmake-repo.git"
             },
             version = "v1.15.3"


### PR DESCRIPTION


Exposes Ultralight's Inspector View through PrismaUI.


https://docs.ultralig.ht/docs/using-the-inspector-view

The Inspector View is Ultralight's built-in Web Inspector (similar to Chrome DevTools) that allows debugging of web content running in PrismaUI views. It provides:
- DOM tree inspection
- Console output
- Network monitoring


Example usage:

https://github.com/langfod/example-skse-plugin/blob/main/src/main.cpp


Scheduling priority was added to SingleThreadExecutor.h
1. Input handler
2. Inspector View (when enabled and open)
3. main PrismaView


### Field Purposes

| Field | Purpose |
|-------|---------|
| `inspectorView` | Ultralight View instance for inspector UI |
| `inspectorVisible` | Toggle inspector overlay on/off |
| `inspectorPointerHover` | Tracks if mouse is currently over inspector bounds (for event routing) |
| `inspectorPos{X,Y}` | Screen-space position where inspector is drawn |
| `inspectorDisplay{Width,Height}` | Size of inspector overlay on screen |
| `inspectorPixelBuffer` | CPU-side buffer holding inspector rendered pixels |
| `inspectorBuffer{Width,Height,Stride}` | Dimensions of CPU buffer |
| `inspectorFrameReady` | Flag: new inspector frame needs upload to GPU |
| `inspectorTexture` | D3D11 GPU texture for inspector |
| `inspectorTextureView` | Shader resource view for rendering |
| `inspectorTexture{Width,Height}` | Dimensions of GPU texture |

---


### API Reference

- Asset management functions (EnsureInspectorAssetsAvailability, AreInspectorAssetsAvailable)
- Lifecycle functions (CreateInspectorView, SetInspectorVisibility, IsInspectorVisible, SetInspectorBounds)
- Rendering pipeline (RenderInspectorView, CopyInspectorBitmapToBuffer, CopyInspectorPixelsToTexture)
- Resource management (ReleaseInspectorTexture, DestroyInspectorResources)

```cpp
// Create inspector view
PrismaUI->CreateInspectorView(view);

// Show/hide inspector overlay
PrismaUI->SetInspectorVisibility(view, true);  // Show
PrismaUI->SetInspectorVisibility(view, false); // Hide

// Check if inspector is visible
bool visible = PrismaUI->IsInspectorVisible(view);

// Position and size inspector (x, y, width, height)
PrismaUI->SetInspectorBounds(view, 960.0f, 0.0f, 960, 540);
```

### Known Issues

Inspector may have a bug in it's three.js initializer and crash when accessing the Layers Tab.
Since it uses Webkit to save you last selected tab this can it to always start in the crashed state. 

One fixed is to clear the savedTab from local storage:

```
      // ============================================
      // Clear inspector tab preference on page load
      // Prevents opening to broken Layers tab
      // ============================================
      try {
        const inspectorTabKey = 'com.apple.WebInspector.selected-tab-index';
        const savedTab = localStorage.getItem(inspectorTabKey);
        if (savedTab !== null) {
          localStorage.removeItem(inspectorTabKey);
          console.log('[Inspector] Tab preference cleared (was:', savedTab, ') - will open to Elements tab');
        }
      } catch (e) {
        console.warn('[Inspector] Could not clear tab preference:', e);
      }
```