### PR TITLE
fix: ultralight thread rare crash issue

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,28 @@
+---
+# This file is optional but helps me ensure the same
+# code style is used in all templates.
+#
+# You can find out more about these configuration files at:
+# https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+#
+# To use this file, configure your IDE to use "clang-format".
+# This will be different for each IDE.
+#
+# You can download "clang-format" by installing LLVM from here:
+# https://github.com/llvm/llvm-project/releases
+#
+# ^ look for the latest release which has a win64.exe installer
+#   and be sure to choose the option to add LLVM to your PATH
+#   when installing
+#
+UseTab: Never
+TabWidth: '4'
+IndentWidth: '4'
+BasedOnStyle: Google
+AccessModifierOffset: -4
+ColumnLimit: 120
+NamespaceIndentation: All
+IndentPPDirectives: BeforeHash
+FixNamespaceComments: false
+
+...

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "external/commonlibsse-ng"]
 	path = external/commonlibsse-ng
 	url = https://github.com/alandtse/CommonLibVR.git
-	branch = ng

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
-﻿[submodule "external/commonlibsse-ng"]
+[submodule "external/commonlibsse-ng"]
 	path = external/commonlibsse-ng
 	url = https://github.com/alandtse/CommonLibVR.git
 	branch = ng

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 ﻿[submodule "external/commonlibsse-ng"]
 	path = external/commonlibsse-ng
 	url = https://github.com/alandtse/CommonLibVR.git
-	branch = e0e0c867b1b06b755755c0e0e64f9b7e00dc009e
+	branch = ng

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ set(CMAKE_JOB_POOL_COMPILE compile)
 set(CMAKE_JOB_POOL_LINK link)
 set(CMAKE_INSTALL_MESSAGE LAZY)
 
-project(PrismaUI VERSION 1.2.1 LANGUAGES CXX)
+project(PrismaUI VERSION 1.2.2 LANGUAGES CXX)
 
 # Set build root for external builds
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")

--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -34,7 +34,7 @@ if(MSVC)
     #string(APPEND CMAKE_CXX_FLAGS " /Zc:threadSafeInit") # Enforce thread-safe initialization
     #string(APPEND CMAKE_CXX_FLAGS " /Zc:trigraphs") # Enforce trigraph rules
     #string(APPEND CMAKE_CXX_FLAGS " /Zc:wchar_t") # Enforce wchar_t rules
-    #string(APPEND CMAKE_CXX_FLAGS_RELEASE  " /GL") # Whole program optimization 
+    #string(APPEND CMAKE_CXX_FLAGS_RELEASE " /GL") # Whole program optimization 
     
     # Apply critical flags to all build configurations (Debug/Release, C/C++)
     # This ensures consistency and overrides CMake defaults that may vary by configuration

--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -10,7 +10,8 @@ if(MSVC)
     # Code generation optimizations
     string(APPEND CMAKE_CXX_FLAGS " /Gy")    # Function-level linking (enables dead code elimination)
     string(APPEND CMAKE_CXX_FLAGS " /Gw")    # Optimize global data (similar to /Gy for globals)
-    string(APPEND CMAKE_CXX_FLAGS " /arch:AVX2")  # Use AVX2 SIMD instructions
+    string(APPEND CMAKE_CXX_FLAGS " /arch:AVX")  # Use AVX (since 2011) SIMD instructions
+    #string(APPEND CMAKE_CXX_FLAGS " /arch:AVX2")  # Use AVX2 (since 2013) SIMD instructions
     
     # Strict C++ standard conformance flags
     string(APPEND CMAKE_CXX_FLAGS " /Zc:inline")
@@ -33,7 +34,7 @@ if(MSVC)
     #string(APPEND CMAKE_CXX_FLAGS " /Zc:threadSafeInit") # Enforce thread-safe initialization
     #string(APPEND CMAKE_CXX_FLAGS " /Zc:trigraphs") # Enforce trigraph rules
     #string(APPEND CMAKE_CXX_FLAGS " /Zc:wchar_t") # Enforce wchar_t rules
-    #string(APPEND CMAKE_CXX_FLAGS " /GL") # Whole program optimization
+    #string(APPEND CMAKE_CXX_FLAGS_RELEASE  " /GL") # Whole program optimization 
     
     # Apply critical flags to all build configurations (Debug/Release, C/C++)
     # This ensures consistency and overrides CMake defaults that may vary by configuration
@@ -51,7 +52,9 @@ if(MSVC)
     
     # Add flags for PDB generation in Release builds
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /Zi")
-    set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /DEBUG /OPT:REF /OPT:ICF")
+    #set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /DEBUG /OPT:REF /OPT:ICF /LTCG") # Enable if using /GL
+    #set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /DEBUG /OPT:REF /OPT:ICF /LTCG")
+    set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /DEBUG /OPT:REF /OPT:ICF") # /GL and /LTCG disabled to see if helps with debugging
     set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /DEBUG /OPT:REF /OPT:ICF")
     
 

--- a/cmake/commonlibsse.cmake
+++ b/cmake/commonlibsse.cmake
@@ -4,6 +4,11 @@
 set(CommonLibPath "external/commonlibsse-ng")
 set(CommonLibName "CommonLibSSE")
 
+# Read CommonLibSSE version from vcpkg.json
+file(READ "${CMAKE_SOURCE_DIR}/${CommonLibPath}/vcpkg.json" VCPKG_JSON_CONTENT)
+string(JSON COMMONLIBSSE_VERSION GET "${VCPKG_JSON_CONTENT}" "version-semver")
+set(COMMONLIBSSE_VERSION "${COMMONLIBSSE_VERSION}" CACHE STRING "CommonLibSSE-NG version" FORCE)
+
 # Save original build type
 set(_saved_build_type "${CMAKE_BUILD_TYPE}")
 
@@ -18,14 +23,18 @@ set(BUILD_TESTS OFF CACHE BOOL "Disable CommonLibSSE tests" FORCE)
 # Check if CommonLibSSE has already been built
 set(COMMONLIB_STAMP_FILE "${BUILD_ROOT}/external_builds/${CommonLibName}.stamp")
 # Add CommonLibSSE-NG as a subdirectory with EXCLUDE_FROM_ALL
-add_subdirectory(${CommonLibPath} "${BUILD_ROOT}/external_builds/${CommonLibName}" EXCLUDE_FROM_ALL)
+add_subdirectory("${CommonLibPath}" "${BUILD_ROOT}/external_builds/${CommonLibName}" EXCLUDE_FROM_ALL)
+
 # Create stamp file after configuration (informational only)
 if(NOT EXISTS "${COMMONLIB_STAMP_FILE}")
     file(WRITE "${COMMONLIB_STAMP_FILE}" "Configured on ${CMAKE_SYSTEM_NAME}")
 endif()
 
 # Include the CommonLibSSE helper cmake functions (provides add_commonlibsse_plugin macro)
-include(${CommonLibPath}/cmake/CommonLibSSE.cmake)
+include("${CommonLibPath}/cmake/CommonLibSSE.cmake")
 
 # Restore original build type for the main project
 set(CMAKE_BUILD_TYPE "${_saved_build_type}")
+
+# Expose CommonLibSSE version to C++ code
+add_compile_definitions(COMMONLIBSSE_VERSION="${COMMONLIBSSE_VERSION}")

--- a/cmake/commonlibsse.cmake
+++ b/cmake/commonlibsse.cmake
@@ -5,8 +5,19 @@ set(CommonLibPath "external/commonlibsse-ng")
 set(CommonLibName "CommonLibSSE")
 
 # Read CommonLibSSE version from vcpkg.json
-file(READ "${CMAKE_SOURCE_DIR}/${CommonLibPath}/vcpkg.json" VCPKG_JSON_CONTENT)
-string(JSON COMMONLIBSSE_VERSION GET "${VCPKG_JSON_CONTENT}" "version-semver")
+set(COMMONLIB_VCPKG_JSON_PATH "${CMAKE_SOURCE_DIR}/${CommonLibPath}/vcpkg.json")
+if(NOT EXISTS "${COMMONLIB_VCPKG_JSON_PATH}")
+    message(FATAL_ERROR
+        "CommonLibSSE-NG vcpkg.json not found at \"${COMMONLIB_VCPKG_JSON_PATH}\". "
+        "Ensure the CommonLibSSE-NG submodule is checked out and includes vcpkg.json with a \"version-semver\" field.")
+endif()
+file(READ "${COMMONLIB_VCPKG_JSON_PATH}" COMMONLIB_VCPKG_JSON_CONTENT)
+string(JSON COMMONLIBSSE_VERSION ERROR_VARIABLE _COMMONLIBSSE_VERSION_JSON_ERROR GET "${COMMONLIB_VCPKG_JSON_CONTENT}" "version-semver")
+if(_COMMONLIBSSE_VERSION_JSON_ERROR)
+    message(FATAL_ERROR
+        "Failed to extract \"version-semver\" from \"${COMMONLIB_VCPKG_JSON_PATH}\": ${_COMMONLIBSSE_VERSION_JSON_ERROR}")
+endif()
+message(STATUS "Configuring CommonLibSSE-NG version ${COMMONLIBSSE_VERSION}")
 set(COMMONLIBSSE_VERSION "${COMMONLIBSSE_VERSION}" CACHE STRING "CommonLibSSE-NG version" FORCE)
 
 # Save original build type

--- a/src/PrismaUI/Core.cpp
+++ b/src/PrismaUI/Core.cpp
@@ -7,7 +7,74 @@
 #include "ViewOperationQueue.h"
 #include "ViewRenderer.h"
 #include "Utils/DllLoader.h"
+#include <eh.h>  // For _set_se_translator
 
+namespace {
+	// SEH exception class to convert structured exceptions to C++ exceptions
+	// Copies all relevant data from EXCEPTION_POINTERS since that pointer is only valid during the translator call
+	class SEHException : public std::exception {
+	public:
+		SEHException(unsigned int code, EXCEPTION_POINTERS* ep) 
+			: code_(code), address_(nullptr), accessType_(0), accessAddress_(0) {
+			if (ep && ep->ExceptionRecord) {
+				address_ = ep->ExceptionRecord->ExceptionAddress;
+				// For access violations, capture the operation type and target address
+				if (code == EXCEPTION_ACCESS_VIOLATION && ep->ExceptionRecord->NumberParameters >= 2) {
+					accessType_ = ep->ExceptionRecord->ExceptionInformation[0];
+					accessAddress_ = ep->ExceptionRecord->ExceptionInformation[1];
+				}
+			}
+		}
+		
+		const char* what() const noexcept override {
+			return "Windows Structured Exception";
+		}
+		
+		unsigned int code() const { return code_; }
+		void* address() const { return address_; }
+		
+		std::string details() const {
+			std::string msg;
+			switch (code_) {
+				case EXCEPTION_ACCESS_VIOLATION:
+					msg = "Access Violation";
+					{
+						const char* op = accessType_ == 0 ? "read" : "write";
+						char buf[128];
+						snprintf(buf, sizeof(buf), " (%s at 0x%p)", op, (void*)accessAddress_);
+						msg += buf;
+					}
+					break;
+				case EXCEPTION_STACK_OVERFLOW: msg = "Stack Overflow"; break;
+				case EXCEPTION_INT_DIVIDE_BY_ZERO: msg = "Integer Divide by Zero"; break;
+				default: 
+					char buf[64];
+					snprintf(buf, sizeof(buf), "Code 0x%08X", code_);
+					msg = buf;
+					break;
+			}
+			return msg;
+		}
+		
+	private:
+		unsigned int code_;
+		void* address_;
+		ULONG_PTR accessType_;     // 0 = read, 1 = write, 8 = DEP violation
+		ULONG_PTR accessAddress_;  // Address that was accessed
+	};
+	
+	void SEHTranslator(unsigned int code, EXCEPTION_POINTERS* ep) {
+		// Stack overflow cannot be safely translated to a C++ exception because
+		// exception handling requires stack space for unwinding, which we don't have.
+		// Let it propagate as an SEH exception - the system will terminate the process.
+		if (code == EXCEPTION_STACK_OVERFLOW) {
+			// Don't throw - just return and let the SEH continue
+			// The process will likely terminate, but that's safer than undefined behavior
+			return;
+		}
+		throw SEHException(code, ep);
+	}
+}
 
 namespace PrismaUI::Core {
 	using namespace PrismaUI::Listeners;
@@ -27,6 +94,7 @@ namespace PrismaUI::Core {
 	ID3D11Device* d3dDevice = nullptr;
 	ID3D11DeviceContext* d3dContext = nullptr;
 	HWND hWnd = nullptr;
+	WNDPROC s_originalWndProc = nullptr;
 	RE::BSGraphics::ScreenSize screenSize;
 
 	std::unique_ptr<DirectX::SpriteBatch> spriteBatch;
@@ -106,7 +174,7 @@ namespace PrismaUI::Core {
 		if (!hWnd && runtimeData.renderWindows && runtimeData.renderWindows->hWnd) {
 			hWnd = reinterpret_cast<HWND>(runtimeData.renderWindows->hWnd);
 			screenSize = renderManager->GetScreenSize();
-			
+
 			static std::atomic<bool> input_handler_initialized = false;
 			bool expected_ih_init = false;
 
@@ -120,7 +188,7 @@ namespace PrismaUI::Core {
 					} else {
 						logger::error("Failed to install WndProc hook!");
 					}
-				});
+	});
 			}
 		}
 		else if (!hWnd) {
@@ -199,65 +267,180 @@ namespace PrismaUI::Core {
 		// Process pending operations for all views
 		ViewOperationQueue::ProcessAllViewOperations();
 
-		ultralightThread.submit([dev = d3dDevice, ctx = d3dContext, hwnd = hWnd]() {
-			if (!dev || !ctx || !hwnd || !renderer) return;
+		auto ultralightFuture = ultralightThread.submit([dev = d3dDevice, ctx = d3dContext, hwnd = hWnd]() {
+			// Enable SEH to C++ exception translation for this thread
+			_set_se_translator(SEHTranslator);
+			
+			try {
+				if (!dev || !ctx || !hwnd) {
+					logger::warn("UI Thread: D3D device/context/hwnd is null, skipping frame.");
+					return;
+				}
+				
+				// Capture renderer locally to avoid race with shutdown
+				auto localRenderer = renderer;
+				if (!localRenderer) {
+					logger::warn("UI Thread: Renderer is null, skipping frame.");
+					return;
+				}
 
-			std::vector<std::shared_ptr<PrismaView>> viewsToInitialize;
-			{
-				std::shared_lock lock(viewsMutex);
-				for (auto& pair : views) {
-					if (pair.second && !pair.second->ultralightView && !pair.second->htmlPathToLoad.empty()) {
-						viewsToInitialize.push_back(pair.second);
+				// Check for views that need recovery after an exception
+				std::vector<std::shared_ptr<PrismaView>> viewsToRecover;
+				{
+					std::shared_lock lock(viewsMutex);
+					for (auto& pair : views) {
+						if (pair.second && pair.second->needsRecovery.load() && pair.second->ultralightView) {
+							viewsToRecover.push_back(pair.second);
+						}
+					}
+				}
+
+				for (auto& viewData : viewsToRecover) {
+					int attempts = viewData->recoveryAttempts.fetch_add(1);
+					if (attempts >= 3) {
+						logger::error("UI Thread: View [{}] recovery failed after {} attempts, giving up", 
+							viewData->id, attempts);
+						viewData->needsRecovery = false;
+						continue;
+					}
+
+					// Use original URL for recovery (the entry point that sets up everything)
+					if (!viewData->originalUrl.empty()) {
+						logger::info("UI Thread: Recovering View [{}] (attempt {}) by reloading original URL: {}", 
+							viewData->id, attempts + 1, viewData->originalUrl);
+						try {
+							viewData->ultralightView->LoadURL(String(viewData->originalUrl.c_str()));
+							viewData->needsRecovery = false;
+							viewData->isLoadingFinished = false;
+							viewData->recoveryAttempts = 0;  // Reset on successful recovery start
+						}
+						catch (...) {
+							logger::error("UI Thread: Failed to initiate recovery for View [{}]", viewData->id);
+						}
+					} else {
+						logger::warn("UI Thread: View [{}] needs recovery but has no originalUrl", viewData->id);
+						viewData->needsRecovery = false;  // Clear flag to avoid infinite loop
+					}
+				}
+
+				std::vector<std::shared_ptr<PrismaView>> viewsToInitialize;
+				{
+					std::shared_lock lock(viewsMutex);
+					for (auto& pair : views) {
+						if (pair.second && !pair.second->ultralightView && !pair.second->htmlPathToLoad.empty()) {
+							viewsToInitialize.push_back(pair.second);
+						}
+					}
+				}
+
+				for (auto& viewData : viewsToInitialize) {
+					if (!viewData || viewData->ultralightView) continue;
+
+					logger::info("UI Thread: Creating View [{}] for path: {}", viewData->id, viewData->htmlPathToLoad);
+
+					if (screenSize.width == 0 || screenSize.height == 0) {
+						logger::error("UI Thread: Cannot create View [{}], screen size is zero.", viewData->id);
+						continue;
+					}
+
+					// Re-check renderer before creating view
+					if (!localRenderer) {
+						logger::warn("UI Thread: Renderer became null during view creation.");
+						break;
+					}
+
+					ViewConfig view_config;
+					view_config.is_accelerated = false;
+					view_config.is_transparent = true;
+					view_config.initial_focus = false;
+					view_config.enable_images = true;
+					view_config.enable_javascript = true;
+					view_config.enable_compositor = false;
+
+					viewData->ultralightView = localRenderer->CreateView(screenSize.width, screenSize.height, view_config, nullptr);
+
+					if (viewData->ultralightView) {
+						viewData->loadListener = std::make_unique<Listeners::MyLoadListener>(viewData->id);
+						viewData->viewListener = std::make_unique<Listeners::MyViewListener>(viewData->id);
+						viewData->ultralightView->set_load_listener(viewData->loadListener.get());
+						viewData->ultralightView->set_view_listener(viewData->viewListener.get());
+						viewData->ultralightView->LoadURL(String(viewData->htmlPathToLoad.c_str()));
+						viewData->ultralightView->Unfocus();
+						viewData->htmlPathToLoad.clear();
+						logger::info("UI Thread: View [{}] successfully created and loading URL.", viewData->id);
+					}
+					else {
+						logger::error("UI Thread: Failed to create Ultralight View for ID [{}].", viewData->id);
+						viewData->htmlPathToLoad = "[CREATION FAILED]";
+					}
+				}
+
+				ProcessEvents();
+
+				logger::trace("UI Thread: Calling renderer->Update()");
+				if (localRenderer) {
+					localRenderer->Update();
+					logger::trace("UI Thread: Calling renderer->RefreshDisplay()");
+					localRenderer->RefreshDisplay(0);
+					logger::trace("UI Thread: Calling renderer->Render()");
+					localRenderer->Render();
+				}
+
+				logger::trace("UI Thread: Calling RenderViews()");
+				RenderViews();
+				logger::trace("UI Thread: RenderViews() completed");
+			}
+			catch (const SEHException& seh) {
+				logger::critical("UI Thread: SEH Exception in render loop: {} at address 0x{:p}", 
+					seh.details(), seh.address());
+				// Mark all views for recovery - the renderer state is likely corrupted
+				{
+					std::shared_lock lock(viewsMutex);
+					for (auto& pair : views) {
+						if (pair.second) {
+							pair.second->needsRecovery = true;
+							logger::warn("View [{}] marked for recovery after SEH exception", pair.first);
+						}
 					}
 				}
 			}
-
-			for (auto& viewData : viewsToInitialize) {
-				if (viewData->ultralightView) continue;
-
-				logger::info("UI Thread: Creating View [{}] for path: {}", viewData->id, viewData->htmlPathToLoad);
-
-				if (screenSize.width == 0 || screenSize.height == 0) {
-					logger::error("UI Thread: Cannot create View [{}], screen size is zero.", viewData->id);
-					continue;
-				}
-
-				ViewConfig view_config;
-				view_config.is_accelerated = false;
-				view_config.is_transparent = true;
-				view_config.initial_focus = false;
-				view_config.enable_images = true;
-				view_config.enable_javascript = true;
-				view_config.enable_compositor = false;
-
-				viewData->ultralightView = renderer->CreateView(screenSize.width, screenSize.height, view_config, nullptr);
-
-				if (viewData->ultralightView) {
-					viewData->loadListener = std::make_unique<Listeners::MyLoadListener>(viewData->id);
-					viewData->viewListener = std::make_unique<Listeners::MyViewListener>(viewData->id);
-					viewData->ultralightView->set_load_listener(viewData->loadListener.get());
-					viewData->ultralightView->set_view_listener(viewData->viewListener.get());
-					viewData->ultralightView->LoadURL(String(viewData->htmlPathToLoad.c_str()));
-					viewData->ultralightView->Unfocus();
-					viewData->htmlPathToLoad.clear();
-					logger::info("UI Thread: View [{}] successfully created and loading URL.", viewData->id);
-				}
-				else {
-					logger::error("UI Thread: Failed to create Ultralight View for ID [{}].", viewData->id);
-					viewData->htmlPathToLoad = "[CREATION FAILED]";
+			catch (const std::exception& e) {
+				logger::critical("UI Thread: Exception in render loop: {}", e.what());
+				// Mark all views for recovery
+				{
+					std::shared_lock lock(viewsMutex);
+					for (auto& pair : views) {
+						if (pair.second) {
+							pair.second->needsRecovery = true;
+						}
+					}
 				}
 			}
-
-			ProcessEvents();
-
-			if (renderer) {
-				renderer->Update();
-				renderer->RefreshDisplay(0);
-				renderer->Render();
+			catch (...) {
+				// Unknown exceptions (likely from Ultralight/WebCore internals)
+				logger::critical("UI Thread: Unknown exception in render loop (likely Ultralight internal error)");
+				// Mark all views for recovery
+				{
+					std::shared_lock lock(viewsMutex);
+					for (auto& pair : views) {
+						if (pair.second) {
+							pair.second->needsRecovery = true;
+						}
+					}
+				}
 			}
-
-			RenderViews();
-			}).get();  // Wait for UI thread to complete before accessing view data
+			});
+		
+		// Wait for UI thread but handle any exceptions that might have escaped
+		try {
+			ultralightFuture.get();
+		}
+		catch (const std::exception& e) {
+			logger::error("D3DPresent: Exception from UI thread: {}", e.what());
+		}
+		catch (...) {
+			logger::error("D3DPresent: Unknown exception from UI thread");
+		}
 
 		std::vector<std::shared_ptr<PrismaView>> viewsToCheck;
 		{
@@ -302,8 +485,6 @@ namespace PrismaUI::Core {
 		spriteBatch.reset();
 		commonStates.reset();
 		logger::debug("DirectXTK resources released.");
-
-		InputHandler::Shutdown();
 
 		d3dDevice = nullptr;
 		d3dContext = nullptr;

--- a/src/PrismaUI/Core.cpp
+++ b/src/PrismaUI/Core.cpp
@@ -94,7 +94,7 @@ namespace PrismaUI::Core {
 	ID3D11Device* d3dDevice = nullptr;
 	ID3D11DeviceContext* d3dContext = nullptr;
 	HWND hWnd = nullptr;
-	WNDPROC s_originalWndProc = nullptr;
+
 	RE::BSGraphics::ScreenSize screenSize;
 
 	std::unique_ptr<DirectX::SpriteBatch> spriteBatch;
@@ -268,8 +268,12 @@ namespace PrismaUI::Core {
 		ViewOperationQueue::ProcessAllViewOperations();
 
 		auto ultralightFuture = ultralightThread.submit([dev = d3dDevice, ctx = d3dContext, hwnd = hWnd]() {
-			// Enable SEH to C++ exception translation for this thread
-			_set_se_translator(SEHTranslator);
+			// Enable SEH to C++ exception translation for this thread (only needs to be set once per thread)
+			static bool sehTranslatorSet = false;
+			if (!sehTranslatorSet) {
+				_set_se_translator(SEHTranslator);
+				sehTranslatorSet = true;
+			}
 			
 			try {
 				if (!dev || !ctx || !hwnd) {
@@ -312,7 +316,7 @@ namespace PrismaUI::Core {
 							viewData->ultralightView->LoadURL(String(viewData->originalUrl.c_str()));
 							viewData->needsRecovery = false;
 							viewData->isLoadingFinished = false;
-							viewData->recoveryAttempts = 0;  // Reset on successful recovery start
+							// recoveryAttempts will be reset by OnFinishLoading on successful load
 						}
 						catch (...) {
 							logger::error("UI Thread: Failed to initiate recovery for View [{}]", viewData->id);
@@ -377,18 +381,13 @@ namespace PrismaUI::Core {
 
 				ProcessEvents();
 
-				logger::trace("UI Thread: Calling renderer->Update()");
 				if (localRenderer) {
 					localRenderer->Update();
-					logger::trace("UI Thread: Calling renderer->RefreshDisplay()");
 					localRenderer->RefreshDisplay(0);
-					logger::trace("UI Thread: Calling renderer->Render()");
 					localRenderer->Render();
 				}
 
-				logger::trace("UI Thread: Calling RenderViews()");
 				RenderViews();
-				logger::trace("UI Thread: RenderViews() completed");
 			}
 			catch (const SEHException& seh) {
 				logger::critical("UI Thread: SEH Exception in render loop: {} at address 0x{:p}", 
@@ -485,6 +484,8 @@ namespace PrismaUI::Core {
 		spriteBatch.reset();
 		commonStates.reset();
 		logger::debug("DirectXTK resources released.");
+
+		InputHandler::Shutdown();
 
 		d3dDevice = nullptr;
 		d3dContext = nullptr;

--- a/src/PrismaUI/Core.cpp
+++ b/src/PrismaUI/Core.cpp
@@ -1,513 +1,574 @@
 ﻿#include "Core.h"
+
+#include <eh.h>  // For _set_se_translator
+
 #include "Communication.h"
 #include "InputHandler.h"
 #include "Inspector.h"
 #include "Listeners.h"
+#include "Utils/DllLoader.h"
 #include "ViewManager.h"
 #include "ViewOperationQueue.h"
 #include "ViewRenderer.h"
-#include "Utils/DllLoader.h"
-#include <eh.h>  // For _set_se_translator
+
 
 namespace {
-	// SEH exception class to convert structured exceptions to C++ exceptions
-	// Copies all relevant data from EXCEPTION_POINTERS since that pointer is only valid during the translator call
-	class SEHException : public std::exception {
-	public:
-		SEHException(unsigned int code, EXCEPTION_POINTERS* ep) 
-			: code_(code), address_(nullptr), accessType_(0), accessAddress_(0) {
-			if (ep && ep->ExceptionRecord) {
-				address_ = ep->ExceptionRecord->ExceptionAddress;
-				// For access violations, capture the operation type and target address
-				if (code == EXCEPTION_ACCESS_VIOLATION && ep->ExceptionRecord->NumberParameters >= 2) {
-					accessType_ = ep->ExceptionRecord->ExceptionInformation[0];
-					accessAddress_ = ep->ExceptionRecord->ExceptionInformation[1];
-				}
-			}
-		}
-		
-		const char* what() const noexcept override {
-			return "Windows Structured Exception";
-		}
-		
-		unsigned int code() const { return code_; }
-		void* address() const { return address_; }
-		
-		std::string details() const {
-			std::string msg;
-			switch (code_) {
-				case EXCEPTION_ACCESS_VIOLATION:
-					msg = "Access Violation";
-					{
-						const char* op = accessType_ == 0 ? "read" : "write";
-						char buf[128];
-						snprintf(buf, sizeof(buf), " (%s at 0x%p)", op, (void*)accessAddress_);
-						msg += buf;
-					}
-					break;
-				case EXCEPTION_STACK_OVERFLOW: msg = "Stack Overflow"; break;
-				case EXCEPTION_INT_DIVIDE_BY_ZERO: msg = "Integer Divide by Zero"; break;
-				default: 
-					char buf[64];
-					snprintf(buf, sizeof(buf), "Code 0x%08X", code_);
-					msg = buf;
-					break;
-			}
-			return msg;
-		}
-		
-	private:
-		unsigned int code_;
-		void* address_;
-		ULONG_PTR accessType_;     // 0 = read, 1 = write, 8 = DEP violation
-		ULONG_PTR accessAddress_;  // Address that was accessed
-	};
-	
-	void SEHTranslator(unsigned int code, EXCEPTION_POINTERS* ep) {
-		// Stack overflow cannot be safely translated to a C++ exception because
-		// exception handling requires stack space for unwinding, which we don't have.
-		// Let it propagate as an SEH exception - the system will terminate the process.
-		if (code == EXCEPTION_STACK_OVERFLOW) {
-			// Don't throw - just return and let the SEH continue
-			// The process will likely terminate, but that's safer than undefined behavior
-			return;
-		}
-		throw SEHException(code, ep);
-	}
+// SEH exception class to convert structured exceptions to C++ exceptions
+// Copies all relevant data from EXCEPTION_POINTERS since that pointer is only
+// valid during the translator call
+class SEHException : public std::exception {
+ public:
+  SEHException(unsigned int code, EXCEPTION_POINTERS* ep)
+      : code_(code), address_(nullptr), accessType_(0), accessAddress_(0) {
+    if (ep && ep->ExceptionRecord) {
+      address_ = ep->ExceptionRecord->ExceptionAddress;
+      // For access violations, capture the operation type and target address
+      if (code == EXCEPTION_ACCESS_VIOLATION &&
+          ep->ExceptionRecord->NumberParameters >= 2) {
+        accessType_ = ep->ExceptionRecord->ExceptionInformation[0];
+        accessAddress_ = ep->ExceptionRecord->ExceptionInformation[1];
+      }
+    }
+  }
+
+  const char* what() const noexcept override {
+    return "Windows Structured Exception";
+  }
+
+  unsigned int code() const { return code_; }
+  void* address() const { return address_; }
+
+  std::string details() const {
+    std::string msg;
+    switch (code_) {
+      case EXCEPTION_ACCESS_VIOLATION:
+        msg = "Access Violation";
+        {
+          const char* op = accessType_ == 0 ? "read" : "write";
+          char buf[128];
+          snprintf(buf, sizeof(buf), " (%s at 0x%p)", op,
+                   (void*)accessAddress_);
+          msg += buf;
+        }
+        break;
+      case EXCEPTION_STACK_OVERFLOW:
+        msg = "Stack Overflow";
+        break;
+      case EXCEPTION_INT_DIVIDE_BY_ZERO:
+        msg = "Integer Divide by Zero";
+        break;
+      default:
+        char buf[64];
+        snprintf(buf, sizeof(buf), "Code 0x%08X", code_);
+        msg = buf;
+        break;
+    }
+    return msg;
+  }
+
+ private:
+  unsigned int code_;
+  void* address_;
+  ULONG_PTR accessType_;     // 0 = read, 1 = write, 8 = DEP violation
+  ULONG_PTR accessAddress_;  // Address that was accessed
+};
+
+void SEHTranslator(unsigned int code, EXCEPTION_POINTERS* ep) {
+  // Stack overflow cannot be safely translated to a C++ exception because
+  // exception handling requires stack space for unwinding, which we don't have.
+  // Let it propagate as an SEH exception - the system will terminate the
+  // process.
+  if (code == EXCEPTION_STACK_OVERFLOW) {
+    // Don't throw - just return and let the SEH continue
+    // The process will likely terminate, but that's safer than undefined
+    // behavior
+    return;
+  }
+  throw SEHException(code, ep);
 }
+}  // namespace
 
 namespace PrismaUI::Core {
-	using namespace PrismaUI::Listeners;
-	using namespace PrismaUI::ViewRenderer;
-	using namespace PrismaUI::ViewManager;
-	using namespace PrismaUI::InputHandler;
+using namespace PrismaUI::Listeners;
+using namespace PrismaUI::ViewRenderer;
+using namespace PrismaUI::ViewManager;
+using namespace PrismaUI::InputHandler;
 
-	SingleThreadExecutor ultralightThread;
-	NanoIdGenerator generator;
-	std::atomic<bool> coreInitialized = false;
-	std::atomic<bool> rendererInitFailed = false;
+SingleThreadExecutor ultralightThread;
+NanoIdGenerator generator;
+std::atomic<bool> coreInitialized = false;
+std::atomic<bool> rendererInitFailed = false;
 
-	// Ultralight platform objects - ownership remains with caller per API docs
-	static std::unique_ptr<MyUltralightLogger> ultralightLogger;
+// Ultralight platform objects - ownership remains with caller per API docs
+static std::unique_ptr<MyUltralightLogger> ultralightLogger;
 
-	RefPtr<Renderer> renderer;
-	ID3D11Device* d3dDevice = nullptr;
-	ID3D11DeviceContext* d3dContext = nullptr;
-	HWND hWnd = nullptr;
+RefPtr<Renderer> renderer;
+ID3D11Device* d3dDevice = nullptr;
+ID3D11DeviceContext* d3dContext = nullptr;
+HWND hWnd = nullptr;
 
-	RE::BSGraphics::ScreenSize screenSize;
+RE::BSGraphics::ScreenSize screenSize;
 
-	std::unique_ptr<DirectX::SpriteBatch> spriteBatch;
-	std::unique_ptr<DirectX::CommonStates> commonStates;
-	Microsoft::WRL::ComPtr<ID3D11ShaderResourceView> cursorTexture;
+std::unique_ptr<DirectX::SpriteBatch> spriteBatch;
+std::unique_ptr<DirectX::CommonStates> commonStates;
+Microsoft::WRL::ComPtr<ID3D11ShaderResourceView> cursorTexture;
 
-	std::map<PrismaViewId, std::shared_ptr<PrismaView>> views;
-	std::shared_mutex viewsMutex;
+std::map<PrismaViewId, std::shared_ptr<PrismaView>> views;
+std::shared_mutex viewsMutex;
 
-	std::map<std::pair<PrismaViewId, std::string>, JSCallbackData> PrismaUI::Core::jsCallbacks;
-	std::mutex PrismaUI::Core::jsCallbacksMutex;
+std::map<std::pair<PrismaViewId, std::string>, JSCallbackData>
+    PrismaUI::Core::jsCallbacks;
+std::mutex PrismaUI::Core::jsCallbacksMutex;
 
-	inline REL::Relocation<Hooks::D3DPresentHook::D3DPresentFunc> RealD3dPresentFunc;
+inline REL::Relocation<Hooks::D3DPresentHook::D3DPresentFunc>
+    RealD3dPresentFunc;
 
-	PrismaView::~PrismaView() {
-		ViewRenderer::ReleaseViewTexture(this);
-	}
+PrismaView::~PrismaView() { ViewRenderer::ReleaseViewTexture(this); }
 
-	void InitializeCoreSystem() {
-		logger::info("Initializing PrismaUI Core System...");
-		InitHooks();
-		
-		const auto basePath = Utils::GetBasePath();
-		ultralightThread.submit([basePath]() {
-			try {
-				Platform& plat = Platform::instance();
-				ultralightLogger = std::make_unique<MyUltralightLogger>();
-				plat.set_logger(ultralightLogger.get());
-				plat.set_font_loader(ultralight::GetPlatformFontLoader());
+void InitializeCoreSystem() {
+  logger::info("Initializing PrismaUI Core System...");
+  InitHooks();
 
-				plat.set_file_system(ultralight::GetPlatformFileSystem(basePath.string().c_str()));
+  const auto basePath = Utils::GetBasePath();
+  ultralightThread
+      .submit([basePath]() {
+        try {
+          Platform& plat = Platform::instance();
+          ultralightLogger = std::make_unique<MyUltralightLogger>();
+          plat.set_logger(ultralightLogger.get());
+          plat.set_font_loader(ultralight::GetPlatformFontLoader());
 
-				Config config;
-				config.resource_path_prefix = "resources/";
-				plat.set_config(config);
+          plat.set_file_system(
+              ultralight::GetPlatformFileSystem(basePath.string().c_str()));
 
-				renderer = Renderer::Create();
-				if (!renderer) {
-					logger::critical("Failed to create Ultralight Renderer!");
-					rendererInitFailed = true;
-				}
-				else {
-					logger::info("Ultralight Platform configured and Renderer created on UI thread.");
-				}
-			}
-			catch (const std::exception& e) {
-				logger::critical("Exception during Ultralight Platform/Renderer init on UI thread: {}", e.what());
-				rendererInitFailed = true;
-			}
-			catch (...) {
-				logger::critical("Unknown exception during Ultralight Platform/Renderer init on UI thread.");
-				rendererInitFailed = true;
-			}
-			}).get();
+          Config config;
+          config.resource_path_prefix = "resources/";
+          plat.set_config(config);
 
-		auto ui = RE::UI::GetSingleton();
-		ui->Register(FocusMenu::MENU_NAME, FocusMenu::Creator);
+          renderer = Renderer::Create();
+          if (!renderer) {
+            logger::critical("Failed to create Ultralight Renderer!");
+            rendererInitFailed = true;
+          } else {
+            logger::info(
+                "Ultralight Platform configured and Renderer created on UI "
+                "thread.");
+          }
+        } catch (const std::exception& e) {
+          logger::critical(
+              "Exception during Ultralight Platform/Renderer init on UI "
+              "thread: {}",
+              e.what());
+          rendererInitFailed = true;
+        } catch (...) {
+          logger::critical(
+              "Unknown exception during Ultralight Platform/Renderer init on "
+              "UI thread.");
+          rendererInitFailed = true;
+        }
+      })
+      .get();
 
-		logger::info("PrismaUI Core System Initialized.");
-	}
+  auto ui = RE::UI::GetSingleton();
+  ui->Register(FocusMenu::MENU_NAME, FocusMenu::Creator);
 
-	void InitHooks() {
-		logger::debug("Installing D3D Present hook...");
-		RealD3dPresentFunc = Hooks::D3DPresentHook::Install(&D3DPresent);
-		logger::info("D3D Present hook installed.");
-	}
-
-	void InitGraphics() {
-		auto* renderManager = RE::BSGraphics::Renderer::GetSingleton();
-		if (!renderManager) {
-			logger::critical("InitGraphics: RenderManager is null!"); return;
-		}
-		auto runtimeData = renderManager->GetRuntimeData();
-		if (!d3dDevice) d3dDevice = reinterpret_cast<ID3D11Device*>(runtimeData.forwarder);
-		if (!d3dContext) d3dContext = reinterpret_cast<ID3D11DeviceContext*>(runtimeData.context);
-
-		if (!hWnd && runtimeData.renderWindows && runtimeData.renderWindows->hWnd) {
-			hWnd = reinterpret_cast<HWND>(runtimeData.renderWindows->hWnd);
-			screenSize = renderManager->GetScreenSize();
-
-			static std::atomic<bool> input_handler_initialized = false;
-			bool expected_ih_init = false;
-
-			if (input_handler_initialized.compare_exchange_strong(expected_ih_init, true)) {
-				Initialize(hWnd, &ultralightThread, &views, &viewsMutex);
-				
-				// Schedule WndProc hook installation on the main thread (required for SetWindowSubclass)
-				SKSE::GetTaskInterface()->AddTask([]() {
-					if (InstallWndProcHook()) {
-						logger::info("WndProc hook installed successfully.");
-					} else {
-						logger::error("Failed to install WndProc hook!");
-					}
-	});
-			}
-		}
-		else if (!hWnd) {
-			logger::warn("InitGraphics: Could not obtain HWND.");
-		}
-
-		if (d3dDevice && d3dContext) {
-			if (!commonStates || !spriteBatch) {
-				try {
-					commonStates = std::make_unique<DirectX::CommonStates>(d3dDevice);
-					spriteBatch = std::make_unique<DirectX::SpriteBatch>(d3dContext);
-					logger::info("DirectXTK SpriteBatch and CommonStates (re)initialized.");
-				}
-				catch (const std::exception& e) {
-					logger::critical("Failed to initialize DirectXTK: {}", e.what());
-					commonStates.reset(); spriteBatch.reset();
-				}
-			}
-
-			if (!cursorTexture && d3dDevice) {
-				auto cursorPath = Utils::GetBasePath() / "misc" / "cursor.png";
-				HRESULT hr = DirectX::CreateWICTextureFromFile(d3dDevice, cursorPath.wstring().c_str(), nullptr, &cursorTexture);
-				if (SUCCEEDED(hr)) {
-					logger::info("Cursor texture loaded successfully.");
-				}
-				else {
-					logger::error("Failed to load cursor texture from '{}'. HRESULT: 0x{:08X}", cursorPath.string(), static_cast<unsigned int>(hr));
-					cursorTexture.Reset();
-				}
-			}
-		}
-		else {
-			logger::error("Cannot initialize DirectXTK: D3D device or context is null.");
-			commonStates.reset(); spriteBatch.reset();
-		}
-	}
-
-	void D3DPresent(uint32_t a_p1) {
-		RealD3dPresentFunc(a_p1);
-
-		if (!coreInitialized || rendererInitFailed) return;
-
-		if (!d3dDevice || !d3dContext || !spriteBatch || !commonStates || !hWnd || screenSize.width == 0) {
-			InitGraphics();
-			if (!d3dDevice || !d3dContext || !spriteBatch || !commonStates || !hWnd || screenSize.width == 0) return;
-		}
-
-		std::vector<PrismaViewId> viewsWithPendingRelease;
-		{
-			std::shared_lock lock(viewsMutex);
-			for (const auto& pair : views) {
-				if (pair.second && pair.second->pendingResourceRelease.load()) {
-					viewsWithPendingRelease.push_back(pair.first);
-				}
-			}
-		}
-
-		for (const auto& viewId : viewsWithPendingRelease) {
-			std::shared_ptr<PrismaView> viewData = nullptr;
-			{
-				std::shared_lock lock(viewsMutex);
-				auto it = views.find(viewId);
-				if (it != views.end()) {
-					viewData = it->second;
-				}
-			}
-
-			if (viewData) {
-				logger::debug("D3DPresent: Releasing D3D resources for View [{}] from render thread", viewId);
-				ViewRenderer::ReleaseViewTexture(viewData.get());
-				Inspector::ReleaseInspectorTexture(viewData.get());
-				viewData->pendingResourceRelease = false;
-			}
-		}
-
-		// Process pending operations for all views
-		ViewOperationQueue::ProcessAllViewOperations();
-
-		auto ultralightFuture = ultralightThread.submit([dev = d3dDevice, ctx = d3dContext, hwnd = hWnd]() {
-			// Enable SEH to C++ exception translation for this thread (only needs to be set once per thread)
-			static bool sehTranslatorSet = false;
-			if (!sehTranslatorSet) {
-				_set_se_translator(SEHTranslator);
-				sehTranslatorSet = true;
-			}
-			
-			try {
-				if (!dev || !ctx || !hwnd) {
-					logger::warn("UI Thread: D3D device/context/hwnd is null, skipping frame.");
-					return;
-				}
-				
-				// Capture renderer locally to avoid race with shutdown
-				auto localRenderer = renderer;
-				if (!localRenderer) {
-					logger::warn("UI Thread: Renderer is null, skipping frame.");
-					return;
-				}
-
-				// Check for views that need recovery after an exception
-				std::vector<std::shared_ptr<PrismaView>> viewsToRecover;
-				{
-					std::shared_lock lock(viewsMutex);
-					for (auto& pair : views) {
-						if (pair.second && pair.second->needsRecovery.load() && pair.second->ultralightView) {
-							viewsToRecover.push_back(pair.second);
-						}
-					}
-				}
-
-				for (auto& viewData : viewsToRecover) {
-					int attempts = viewData->recoveryAttempts.fetch_add(1);
-					if (attempts >= 3) {
-						logger::error("UI Thread: View [{}] recovery failed after {} attempts, giving up", 
-							viewData->id, attempts);
-						viewData->needsRecovery = false;
-						continue;
-					}
-
-					// Use original URL for recovery (the entry point that sets up everything)
-					if (!viewData->originalUrl.empty()) {
-						logger::info("UI Thread: Recovering View [{}] (attempt {}) by reloading original URL: {}", 
-							viewData->id, attempts + 1, viewData->originalUrl);
-						try {
-							viewData->ultralightView->LoadURL(String(viewData->originalUrl.c_str()));
-							viewData->needsRecovery = false;
-							viewData->isLoadingFinished = false;
-							// recoveryAttempts will be reset by OnFinishLoading on successful load
-						}
-						catch (...) {
-							logger::error("UI Thread: Failed to initiate recovery for View [{}]", viewData->id);
-						}
-					} else {
-						logger::warn("UI Thread: View [{}] needs recovery but has no originalUrl", viewData->id);
-						viewData->needsRecovery = false;  // Clear flag to avoid infinite loop
-					}
-				}
-
-				std::vector<std::shared_ptr<PrismaView>> viewsToInitialize;
-				{
-					std::shared_lock lock(viewsMutex);
-					for (auto& pair : views) {
-						if (pair.second && !pair.second->ultralightView && !pair.second->htmlPathToLoad.empty()) {
-							viewsToInitialize.push_back(pair.second);
-						}
-					}
-				}
-
-				for (auto& viewData : viewsToInitialize) {
-					if (!viewData || viewData->ultralightView) continue;
-
-					logger::info("UI Thread: Creating View [{}] for path: {}", viewData->id, viewData->htmlPathToLoad);
-
-					if (screenSize.width == 0 || screenSize.height == 0) {
-						logger::error("UI Thread: Cannot create View [{}], screen size is zero.", viewData->id);
-						continue;
-					}
-
-					// Re-check renderer before creating view
-					if (!localRenderer) {
-						logger::warn("UI Thread: Renderer became null during view creation.");
-						break;
-					}
-
-					ViewConfig view_config;
-					view_config.is_accelerated = false;
-					view_config.is_transparent = true;
-					view_config.initial_focus = false;
-					view_config.enable_images = true;
-					view_config.enable_javascript = true;
-					view_config.enable_compositor = false;
-
-					viewData->ultralightView = localRenderer->CreateView(screenSize.width, screenSize.height, view_config, nullptr);
-
-					if (viewData->ultralightView) {
-						viewData->loadListener = std::make_unique<Listeners::MyLoadListener>(viewData->id);
-						viewData->viewListener = std::make_unique<Listeners::MyViewListener>(viewData->id);
-						viewData->ultralightView->set_load_listener(viewData->loadListener.get());
-						viewData->ultralightView->set_view_listener(viewData->viewListener.get());
-						viewData->ultralightView->LoadURL(String(viewData->htmlPathToLoad.c_str()));
-						viewData->ultralightView->Unfocus();
-						viewData->htmlPathToLoad.clear();
-						logger::info("UI Thread: View [{}] successfully created and loading URL.", viewData->id);
-					}
-					else {
-						logger::error("UI Thread: Failed to create Ultralight View for ID [{}].", viewData->id);
-						viewData->htmlPathToLoad = "[CREATION FAILED]";
-					}
-				}
-
-				ProcessEvents();
-
-				if (localRenderer) {
-					localRenderer->Update();
-					localRenderer->RefreshDisplay(0);
-					localRenderer->Render();
-				}
-
-				RenderViews();
-			}
-			catch (const SEHException& seh) {
-				logger::critical("UI Thread: SEH Exception in render loop: {} at address 0x{:p}", 
-					seh.details(), seh.address());
-				// Mark all views for recovery - the renderer state is likely corrupted
-				{
-					std::shared_lock lock(viewsMutex);
-					for (auto& pair : views) {
-						if (pair.second) {
-							pair.second->needsRecovery = true;
-							logger::warn("View [{}] marked for recovery after SEH exception", pair.first);
-						}
-					}
-				}
-			}
-			catch (const std::exception& e) {
-				logger::critical("UI Thread: Exception in render loop: {}", e.what());
-				// Mark all views for recovery
-				{
-					std::shared_lock lock(viewsMutex);
-					for (auto& pair : views) {
-						if (pair.second) {
-							pair.second->needsRecovery = true;
-						}
-					}
-				}
-			}
-			catch (...) {
-				// Unknown exceptions (likely from Ultralight/WebCore internals)
-				logger::critical("UI Thread: Unknown exception in render loop (likely Ultralight internal error)");
-				// Mark all views for recovery
-				{
-					std::shared_lock lock(viewsMutex);
-					for (auto& pair : views) {
-						if (pair.second) {
-							pair.second->needsRecovery = true;
-						}
-					}
-				}
-			}
-			});
-		
-		// Wait for UI thread but handle any exceptions that might have escaped
-		try {
-			ultralightFuture.get();
-		}
-		catch (const std::exception& e) {
-			logger::error("D3DPresent: Exception from UI thread: {}", e.what());
-		}
-		catch (...) {
-			logger::error("D3DPresent: Unknown exception from UI thread");
-		}
-
-		std::vector<std::shared_ptr<PrismaView>> viewsToCheck;
-		{
-			std::shared_lock lock(viewsMutex);
-			viewsToCheck.reserve(views.size());
-			for (const auto& pair : views) {
-				if (pair.second && pair.second->ultralightView) {
-					viewsToCheck.push_back(pair.second);
-				}
-			}
-		}
-
-		for (const auto& viewData : viewsToCheck) {
-			UpdateSingleTextureFromBuffer(viewData);
-		}
-
-		DrawViews();
-		DrawCursor();
-	}
-
-	void Shutdown() {
-		logger::info("Shutting down PrismaUI Core System...");
-
-		std::vector<PrismaViewId> viewIdsToDestroy;
-		{
-			std::shared_lock lock(viewsMutex);
-			for (const auto& pair : views) {
-				viewIdsToDestroy.push_back(pair.first);
-			}
-		}
-
-		for (const auto& id : viewIdsToDestroy) {
-			try {
-				ViewManager::Destroy(id);
-			}
-			catch (const std::exception& e) {
-				logger::error("Error destroying view [{}] during shutdown: {}", id, e.what());
-			}
-		}
-
-		cursorTexture.Reset();
-		spriteBatch.reset();
-		commonStates.reset();
-		logger::debug("DirectXTK resources released.");
-
-		InputHandler::Shutdown();
-
-		d3dDevice = nullptr;
-		d3dContext = nullptr;
-		hWnd = nullptr;
-
-		{
-			std::unique_lock lock(viewsMutex);
-			views.clear();
-		}
-		if (renderer) {
-			// Move renderer to the lambda so it's the sole owner,
-			// ensuring release happens on the UI thread
-			ultralightThread.submit([renderer_moved = std::move(renderer)]() mutable {
-				logger::info("Releasing global renderer on UI thread.");
-				renderer_moved = nullptr;
-			}).get();
-		}
-
-		// Release Ultralight platform objects after renderer is destroyed
-		ultralightLogger.reset();
-
-		coreInitialized = false;
-		logger::info("PrismaUI Core System shut down complete.");
-	}
+  logger::info("PrismaUI Core System Initialized.");
 }
+
+void InitHooks() {
+  logger::debug("Installing D3D Present hook...");
+  RealD3dPresentFunc = Hooks::D3DPresentHook::Install(&D3DPresent);
+  logger::info("D3D Present hook installed.");
+}
+
+void InitGraphics() {
+  auto* renderManager = RE::BSGraphics::Renderer::GetSingleton();
+  if (!renderManager) {
+    logger::critical("InitGraphics: RenderManager is null!");
+    return;
+  }
+  auto runtimeData = renderManager->GetRuntimeData();
+  if (!d3dDevice)
+    d3dDevice = reinterpret_cast<ID3D11Device*>(runtimeData.forwarder);
+  if (!d3dContext)
+    d3dContext = reinterpret_cast<ID3D11DeviceContext*>(runtimeData.context);
+
+  if (!hWnd && runtimeData.renderWindows && runtimeData.renderWindows->hWnd) {
+    hWnd = reinterpret_cast<HWND>(runtimeData.renderWindows->hWnd);
+    screenSize = renderManager->GetScreenSize();
+
+    static std::atomic<bool> input_handler_initialized = false;
+    bool expected_ih_init = false;
+
+    if (input_handler_initialized.compare_exchange_strong(expected_ih_init,
+                                                          true)) {
+      Initialize(hWnd, &ultralightThread, &views, &viewsMutex);
+
+      // Schedule WndProc hook installation on the main thread (required for
+      // SetWindowSubclass)
+      SKSE::GetTaskInterface()->AddTask([]() {
+        if (InstallWndProcHook()) {
+          logger::info("WndProc hook installed successfully.");
+        } else {
+          logger::error("Failed to install WndProc hook!");
+        }
+      });
+    }
+  } else if (!hWnd) {
+    logger::warn("InitGraphics: Could not obtain HWND.");
+  }
+
+  if (d3dDevice && d3dContext) {
+    if (!commonStates || !spriteBatch) {
+      try {
+        commonStates = std::make_unique<DirectX::CommonStates>(d3dDevice);
+        spriteBatch = std::make_unique<DirectX::SpriteBatch>(d3dContext);
+        logger::info("DirectXTK SpriteBatch and CommonStates (re)initialized.");
+      } catch (const std::exception& e) {
+        logger::critical("Failed to initialize DirectXTK: {}", e.what());
+        commonStates.reset();
+        spriteBatch.reset();
+      }
+    }
+
+    if (!cursorTexture && d3dDevice) {
+      auto cursorPath = Utils::GetBasePath() / "misc" / "cursor.png";
+      HRESULT hr = DirectX::CreateWICTextureFromFile(
+          d3dDevice, cursorPath.wstring().c_str(), nullptr, &cursorTexture);
+      if (SUCCEEDED(hr)) {
+        logger::info("Cursor texture loaded successfully.");
+      } else {
+        logger::error(
+            "Failed to load cursor texture from '{}'. HRESULT: 0x{:08X}",
+            cursorPath.string(), static_cast<unsigned int>(hr));
+        cursorTexture.Reset();
+      }
+    }
+  } else {
+    logger::error(
+        "Cannot initialize DirectXTK: D3D device or context is null.");
+    commonStates.reset();
+    spriteBatch.reset();
+  }
+}
+
+void D3DPresent(uint32_t a_p1) {
+  RealD3dPresentFunc(a_p1);
+
+  if (!coreInitialized || rendererInitFailed) return;
+
+  if (!d3dDevice || !d3dContext || !spriteBatch || !commonStates || !hWnd ||
+      screenSize.width == 0) {
+    InitGraphics();
+    if (!d3dDevice || !d3dContext || !spriteBatch || !commonStates || !hWnd ||
+        screenSize.width == 0)
+      return;
+  }
+
+  std::vector<PrismaViewId> viewsWithPendingRelease;
+  {
+    std::shared_lock lock(viewsMutex);
+    for (const auto& pair : views) {
+      if (pair.second && pair.second->pendingResourceRelease.load()) {
+        viewsWithPendingRelease.push_back(pair.first);
+      }
+    }
+  }
+
+  for (const auto& viewId : viewsWithPendingRelease) {
+    std::shared_ptr<PrismaView> viewData = nullptr;
+    {
+      std::shared_lock lock(viewsMutex);
+      auto it = views.find(viewId);
+      if (it != views.end()) {
+        viewData = it->second;
+      }
+    }
+
+    if (viewData) {
+      logger::debug(
+          "D3DPresent: Releasing D3D resources for View [{}] from render "
+          "thread",
+          viewId);
+      ViewRenderer::ReleaseViewTexture(viewData.get());
+      Inspector::ReleaseInspectorTexture(viewData.get());
+      viewData->pendingResourceRelease = false;
+    }
+  }
+
+  // Process pending operations for all views
+  ViewOperationQueue::ProcessAllViewOperations();
+
+  auto ultralightFuture = ultralightThread.submit([dev = d3dDevice,
+                                                   ctx = d3dContext,
+                                                   hwnd = hWnd]() {
+    // Enable SEH to C++ exception translation for this thread (only needs to be
+    // set once per thread)
+    static bool sehTranslatorSet = false;
+    if (!sehTranslatorSet) {
+      _set_se_translator(SEHTranslator);
+      sehTranslatorSet = true;
+    }
+
+    try {
+      if (!dev || !ctx || !hwnd) {
+        logger::warn(
+            "UI Thread: D3D device/context/hwnd is null, skipping frame.");
+        return;
+      }
+
+      // Capture renderer locally to avoid race with shutdown
+      auto localRenderer = renderer;
+      if (!localRenderer) {
+        logger::warn("UI Thread: Renderer is null, skipping frame.");
+        return;
+      }
+
+      // Check for views that need recovery after an exception
+      std::vector<std::shared_ptr<PrismaView>> viewsToRecover;
+      {
+        std::shared_lock lock(viewsMutex);
+        for (auto& pair : views) {
+          if (pair.second && pair.second->needsRecovery.load() &&
+              pair.second->ultralightView) {
+            viewsToRecover.push_back(pair.second);
+          }
+        }
+      }
+
+      for (auto& viewData : viewsToRecover) {
+        int attempts = viewData->recoveryAttempts.fetch_add(1);
+        if (attempts >= 3) {
+          logger::error(
+              "UI Thread: View [{}] recovery failed after {} attempts, giving "
+              "up",
+              viewData->id, attempts);
+          viewData->needsRecovery = false;
+          continue;
+        }
+
+        // Use original URL for recovery (the entry point that sets up
+        // everything)
+        if (!viewData->originalUrl.empty()) {
+          logger::info(
+              "UI Thread: Recovering View [{}] (attempt {}) by reloading "
+              "original URL: {}",
+              viewData->id, attempts + 1, viewData->originalUrl);
+          try {
+            viewData->ultralightView->LoadURL(
+                String(viewData->originalUrl.c_str()));
+            viewData->needsRecovery = false;
+            viewData->isLoadingFinished = false;
+            // recoveryAttempts will be reset by OnFinishLoading on successful
+            // load
+          } catch (...) {
+            logger::error(
+                "UI Thread: Failed to initiate recovery for View [{}]",
+                viewData->id);
+          }
+        } else {
+          logger::warn(
+              "UI Thread: View [{}] needs recovery but has no originalUrl",
+              viewData->id);
+          viewData->needsRecovery = false;  // Clear flag to avoid infinite loop
+        }
+      }
+
+      std::vector<std::shared_ptr<PrismaView>> viewsToInitialize;
+      {
+        std::shared_lock lock(viewsMutex);
+        for (auto& pair : views) {
+          if (pair.second && !pair.second->ultralightView &&
+              !pair.second->htmlPathToLoad.empty()) {
+            viewsToInitialize.push_back(pair.second);
+          }
+        }
+      }
+
+      for (auto& viewData : viewsToInitialize) {
+        if (!viewData || viewData->ultralightView) continue;
+
+        logger::info("UI Thread: Creating View [{}] for path: {}", viewData->id,
+                     viewData->htmlPathToLoad);
+
+        if (screenSize.width == 0 || screenSize.height == 0) {
+          logger::error(
+              "UI Thread: Cannot create View [{}], screen size is zero.",
+              viewData->id);
+          continue;
+        }
+
+        // Re-check renderer before creating view
+        if (!localRenderer) {
+          logger::warn("UI Thread: Renderer became null during view creation.");
+          break;
+        }
+
+        ViewConfig view_config;
+        view_config.is_accelerated = false;
+        view_config.is_transparent = true;
+        view_config.initial_focus = false;
+        view_config.enable_images = true;
+        view_config.enable_javascript = true;
+        view_config.enable_compositor = false;
+
+        viewData->ultralightView = localRenderer->CreateView(
+            screenSize.width, screenSize.height, view_config, nullptr);
+
+        if (viewData->ultralightView) {
+          viewData->loadListener =
+              std::make_unique<Listeners::MyLoadListener>(viewData->id);
+          viewData->viewListener =
+              std::make_unique<Listeners::MyViewListener>(viewData->id);
+          viewData->ultralightView->set_load_listener(
+              viewData->loadListener.get());
+          viewData->ultralightView->set_view_listener(
+              viewData->viewListener.get());
+          viewData->ultralightView->LoadURL(
+              String(viewData->htmlPathToLoad.c_str()));
+          viewData->ultralightView->Unfocus();
+          viewData->htmlPathToLoad.clear();
+          logger::info(
+              "UI Thread: View [{}] successfully created and loading URL.",
+              viewData->id);
+        } else {
+          logger::error(
+              "UI Thread: Failed to create Ultralight View for ID [{}].",
+              viewData->id);
+          viewData->htmlPathToLoad = "[CREATION FAILED]";
+        }
+      }
+
+      ProcessEvents();
+
+      if (localRenderer) {
+        localRenderer->Update();
+        localRenderer->RefreshDisplay(0);
+        localRenderer->Render();
+      }
+
+      RenderViews();
+    } catch (const SEHException& seh) {
+      logger::critical(
+          "UI Thread: SEH Exception in render loop: {} at address 0x{:p}",
+          seh.details(), seh.address());
+      // Mark all views for recovery - the renderer state is likely corrupted
+      {
+        std::shared_lock lock(viewsMutex);
+        for (auto& pair : views) {
+          if (pair.second) {
+            pair.second->needsRecovery = true;
+            logger::warn("View [{}] marked for recovery after SEH exception",
+                         pair.first);
+          }
+        }
+      }
+    } catch (const std::exception& e) {
+      logger::critical("UI Thread: Exception in render loop: {}", e.what());
+      // Mark all views for recovery
+      {
+        std::shared_lock lock(viewsMutex);
+        for (auto& pair : views) {
+          if (pair.second) {
+            pair.second->needsRecovery = true;
+          }
+        }
+      }
+    } catch (...) {
+      // Unknown exceptions (likely from Ultralight/WebCore internals)
+      logger::critical(
+          "UI Thread: Unknown exception in render loop (likely Ultralight "
+          "internal error)");
+      // Mark all views for recovery
+      {
+        std::shared_lock lock(viewsMutex);
+        for (auto& pair : views) {
+          if (pair.second) {
+            pair.second->needsRecovery = true;
+          }
+        }
+      }
+    }
+  });
+
+  // Wait for UI thread but handle any exceptions that might have escaped
+  try {
+    ultralightFuture.get();
+  } catch (const std::exception& e) {
+    logger::error("D3DPresent: Exception from UI thread: {}", e.what());
+  } catch (...) {
+    logger::error("D3DPresent: Unknown exception from UI thread");
+  }
+
+  std::vector<std::shared_ptr<PrismaView>> viewsToCheck;
+  {
+    std::shared_lock lock(viewsMutex);
+    viewsToCheck.reserve(views.size());
+    for (const auto& pair : views) {
+      if (pair.second && pair.second->ultralightView) {
+        viewsToCheck.push_back(pair.second);
+      }
+    }
+  }
+
+  for (const auto& viewData : viewsToCheck) {
+    UpdateSingleTextureFromBuffer(viewData);
+  }
+
+  DrawViews();
+  DrawCursor();
+}
+
+void Shutdown() {
+  logger::info("Shutting down PrismaUI Core System...");
+
+  std::vector<PrismaViewId> viewIdsToDestroy;
+  {
+    std::shared_lock lock(viewsMutex);
+    for (const auto& pair : views) {
+      viewIdsToDestroy.push_back(pair.first);
+    }
+  }
+
+  for (const auto& id : viewIdsToDestroy) {
+    try {
+      ViewManager::Destroy(id);
+    } catch (const std::exception& e) {
+      logger::error("Error destroying view [{}] during shutdown: {}", id,
+                    e.what());
+    }
+  }
+
+  cursorTexture.Reset();
+  spriteBatch.reset();
+  commonStates.reset();
+  logger::debug("DirectXTK resources released.");
+
+  InputHandler::Shutdown();
+
+  d3dDevice = nullptr;
+  d3dContext = nullptr;
+  hWnd = nullptr;
+
+  {
+    std::unique_lock lock(viewsMutex);
+    views.clear();
+  }
+  if (renderer) {
+    // Move renderer to the lambda so it's the sole owner,
+    // ensuring release happens on the UI thread
+    ultralightThread
+        .submit([renderer_moved = std::move(renderer)]() mutable {
+          logger::info("Releasing global renderer on UI thread.");
+          renderer_moved = nullptr;
+        })
+        .get();
+  }
+
+  // Release Ultralight platform objects after renderer is destroyed
+  ultralightLogger.reset();
+
+  coreInitialized = false;
+  logger::info("PrismaUI Core System shut down complete.");
+}
+}  // namespace PrismaUI::Core

--- a/src/PrismaUI/Core.cpp
+++ b/src/PrismaUI/Core.cpp
@@ -11,564 +11,523 @@
 #include "ViewOperationQueue.h"
 #include "ViewRenderer.h"
 
-
 namespace {
-// SEH exception class to convert structured exceptions to C++ exceptions
-// Copies all relevant data from EXCEPTION_POINTERS since that pointer is only
-// valid during the translator call
-class SEHException : public std::exception {
- public:
-  SEHException(unsigned int code, EXCEPTION_POINTERS* ep)
-      : code_(code), address_(nullptr), accessType_(0), accessAddress_(0) {
-    if (ep && ep->ExceptionRecord) {
-      address_ = ep->ExceptionRecord->ExceptionAddress;
-      // For access violations, capture the operation type and target address
-      if (code == EXCEPTION_ACCESS_VIOLATION &&
-          ep->ExceptionRecord->NumberParameters >= 2) {
-        accessType_ = ep->ExceptionRecord->ExceptionInformation[0];
-        accessAddress_ = ep->ExceptionRecord->ExceptionInformation[1];
-      }
-    }
-  }
-
-  const char* what() const noexcept override {
-    return "Windows Structured Exception";
-  }
-
-  unsigned int code() const { return code_; }
-  void* address() const { return address_; }
-
-  std::string details() const {
-    std::string msg;
-    switch (code_) {
-      case EXCEPTION_ACCESS_VIOLATION:
-        msg = "Access Violation";
-        {
-          const char* op = accessType_ == 0 ? "read" : "write";
-          char buf[128];
-          snprintf(buf, sizeof(buf), " (%s at 0x%p)", op,
-                   (void*)accessAddress_);
-          msg += buf;
+    // SEH exception class to convert structured exceptions to C++ exceptions
+    // Copies all relevant data from EXCEPTION_POINTERS since that pointer is only
+    // valid during the translator call
+    class SEHException : public std::exception {
+    public:
+        SEHException(unsigned int code, EXCEPTION_POINTERS* ep)
+            : code_(code), address_(nullptr), accessType_(0), accessAddress_(0) {
+            if (ep && ep->ExceptionRecord) {
+                address_ = ep->ExceptionRecord->ExceptionAddress;
+                // For access violations, capture the operation type and target address
+                if (code == EXCEPTION_ACCESS_VIOLATION && ep->ExceptionRecord->NumberParameters >= 2) {
+                    accessType_ = ep->ExceptionRecord->ExceptionInformation[0];
+                    accessAddress_ = ep->ExceptionRecord->ExceptionInformation[1];
+                }
+            }
         }
-        break;
-      case EXCEPTION_STACK_OVERFLOW:
-        msg = "Stack Overflow";
-        break;
-      case EXCEPTION_INT_DIVIDE_BY_ZERO:
-        msg = "Integer Divide by Zero";
-        break;
-      default:
-        char buf[64];
-        snprintf(buf, sizeof(buf), "Code 0x%08X", code_);
-        msg = buf;
-        break;
+
+        const char* what() const noexcept override { return "Windows Structured Exception"; }
+
+        unsigned int code() const { return code_; }
+        void* address() const { return address_; }
+
+        std::string details() const {
+            std::string msg;
+            switch (code_) {
+                case EXCEPTION_ACCESS_VIOLATION:
+                    msg = "Access Violation";
+                    {
+                        const char* op = accessType_ == 0 ? "read" : "write";
+                        char buf[128];
+                        snprintf(buf, sizeof(buf), " (%s at 0x%p)", op, (void*)accessAddress_);
+                        msg += buf;
+                    }
+                    break;
+                case EXCEPTION_STACK_OVERFLOW:
+                    msg = "Stack Overflow";
+                    break;
+                case EXCEPTION_INT_DIVIDE_BY_ZERO:
+                    msg = "Integer Divide by Zero";
+                    break;
+                default:
+                    char buf[64];
+                    snprintf(buf, sizeof(buf), "Code 0x%08X", code_);
+                    msg = buf;
+                    break;
+            }
+            return msg;
+        }
+
+    private:
+        unsigned int code_;
+        void* address_;
+        ULONG_PTR accessType_;     // 0 = read, 1 = write, 8 = DEP violation
+        ULONG_PTR accessAddress_;  // Address that was accessed
+    };
+
+    void SEHTranslator(unsigned int code, EXCEPTION_POINTERS* ep) {
+        // Stack overflow cannot be safely translated to a C++ exception because
+        // exception handling requires stack space for unwinding, which we don't have.
+        // Let it propagate as an SEH exception - the system will terminate the
+        // process.
+        if (code == EXCEPTION_STACK_OVERFLOW) {
+            // Don't throw - just return and let the SEH continue
+            // The process will likely terminate, but that's safer than undefined
+            // behavior
+            return;
+        }
+        throw SEHException(code, ep);
     }
-    return msg;
-  }
-
- private:
-  unsigned int code_;
-  void* address_;
-  ULONG_PTR accessType_;     // 0 = read, 1 = write, 8 = DEP violation
-  ULONG_PTR accessAddress_;  // Address that was accessed
-};
-
-void SEHTranslator(unsigned int code, EXCEPTION_POINTERS* ep) {
-  // Stack overflow cannot be safely translated to a C++ exception because
-  // exception handling requires stack space for unwinding, which we don't have.
-  // Let it propagate as an SEH exception - the system will terminate the
-  // process.
-  if (code == EXCEPTION_STACK_OVERFLOW) {
-    // Don't throw - just return and let the SEH continue
-    // The process will likely terminate, but that's safer than undefined
-    // behavior
-    return;
-  }
-  throw SEHException(code, ep);
-}
 }  // namespace
 
 namespace PrismaUI::Core {
-using namespace PrismaUI::Listeners;
-using namespace PrismaUI::ViewRenderer;
-using namespace PrismaUI::ViewManager;
-using namespace PrismaUI::InputHandler;
+    using namespace PrismaUI::Listeners;
+    using namespace PrismaUI::ViewRenderer;
+    using namespace PrismaUI::ViewManager;
+    using namespace PrismaUI::InputHandler;
 
-SingleThreadExecutor ultralightThread;
-NanoIdGenerator generator;
-std::atomic<bool> coreInitialized = false;
-std::atomic<bool> rendererInitFailed = false;
+    SingleThreadExecutor ultralightThread;
+    NanoIdGenerator generator;
+    std::atomic<bool> coreInitialized = false;
+    std::atomic<bool> rendererInitFailed = false;
 
-// Ultralight platform objects - ownership remains with caller per API docs
-static std::unique_ptr<MyUltralightLogger> ultralightLogger;
+    // Ultralight platform objects - ownership remains with caller per API docs
+    static std::unique_ptr<MyUltralightLogger> ultralightLogger;
 
-RefPtr<Renderer> renderer;
-ID3D11Device* d3dDevice = nullptr;
-ID3D11DeviceContext* d3dContext = nullptr;
-HWND hWnd = nullptr;
+    RefPtr<Renderer> renderer;
+    ID3D11Device* d3dDevice = nullptr;
+    ID3D11DeviceContext* d3dContext = nullptr;
+    HWND hWnd = nullptr;
 
-RE::BSGraphics::ScreenSize screenSize;
+    RE::BSGraphics::ScreenSize screenSize;
 
-std::unique_ptr<DirectX::SpriteBatch> spriteBatch;
-std::unique_ptr<DirectX::CommonStates> commonStates;
-Microsoft::WRL::ComPtr<ID3D11ShaderResourceView> cursorTexture;
+    std::unique_ptr<DirectX::SpriteBatch> spriteBatch;
+    std::unique_ptr<DirectX::CommonStates> commonStates;
+    Microsoft::WRL::ComPtr<ID3D11ShaderResourceView> cursorTexture;
 
-std::map<PrismaViewId, std::shared_ptr<PrismaView>> views;
-std::shared_mutex viewsMutex;
+    std::map<PrismaViewId, std::shared_ptr<PrismaView>> views;
+    std::shared_mutex viewsMutex;
 
-std::map<std::pair<PrismaViewId, std::string>, JSCallbackData>
-    PrismaUI::Core::jsCallbacks;
-std::mutex PrismaUI::Core::jsCallbacksMutex;
+    std::map<std::pair<PrismaViewId, std::string>, JSCallbackData> PrismaUI::Core::jsCallbacks;
+    std::mutex PrismaUI::Core::jsCallbacksMutex;
 
-inline REL::Relocation<Hooks::D3DPresentHook::D3DPresentFunc>
-    RealD3dPresentFunc;
+    inline REL::Relocation<Hooks::D3DPresentHook::D3DPresentFunc> RealD3dPresentFunc;
 
-PrismaView::~PrismaView() { ViewRenderer::ReleaseViewTexture(this); }
+    PrismaView::~PrismaView() { ViewRenderer::ReleaseViewTexture(this); }
 
-void InitializeCoreSystem() {
-  logger::info("Initializing PrismaUI Core System...");
-  InitHooks();
+    void InitializeCoreSystem() {
+        logger::info("Initializing PrismaUI Core System...");
+        InitHooks();
 
-  const auto basePath = Utils::GetBasePath();
-  ultralightThread
-      .submit([basePath]() {
+        const auto basePath = Utils::GetBasePath();
+        ultralightThread
+            .submit([basePath]() {
+                try {
+                    Platform& plat = Platform::instance();
+                    ultralightLogger = std::make_unique<MyUltralightLogger>();
+                    plat.set_logger(ultralightLogger.get());
+                    plat.set_font_loader(ultralight::GetPlatformFontLoader());
+
+                    plat.set_file_system(ultralight::GetPlatformFileSystem(basePath.string().c_str()));
+
+                    Config config;
+                    config.resource_path_prefix = "resources/";
+                    plat.set_config(config);
+
+                    renderer = Renderer::Create();
+                    if (!renderer) {
+                        logger::critical("Failed to create Ultralight Renderer!");
+                        rendererInitFailed = true;
+                    } else {
+                        logger::info(
+                            "Ultralight Platform configured and Renderer created on UI "
+                            "thread.");
+                    }
+                } catch (const std::exception& e) {
+                    logger::critical(
+                        "Exception during Ultralight Platform/Renderer init on UI "
+                        "thread: {}",
+                        e.what());
+                    rendererInitFailed = true;
+                } catch (...) {
+                    logger::critical(
+                        "Unknown exception during Ultralight Platform/Renderer init on "
+                        "UI thread.");
+                    rendererInitFailed = true;
+                }
+            })
+            .get();
+
+        auto ui = RE::UI::GetSingleton();
+        ui->Register(FocusMenu::MENU_NAME, FocusMenu::Creator);
+
+        logger::info("PrismaUI Core System Initialized.");
+    }
+
+    void InitHooks() {
+        logger::debug("Installing D3D Present hook...");
+        RealD3dPresentFunc = Hooks::D3DPresentHook::Install(&D3DPresent);
+        logger::info("D3D Present hook installed.");
+    }
+
+    void InitGraphics() {
+        auto* renderManager = RE::BSGraphics::Renderer::GetSingleton();
+        if (!renderManager) {
+            logger::critical("InitGraphics: RenderManager is null!");
+            return;
+        }
+        auto runtimeData = renderManager->GetRuntimeData();
+        if (!d3dDevice) d3dDevice = reinterpret_cast<ID3D11Device*>(runtimeData.forwarder);
+        if (!d3dContext) d3dContext = reinterpret_cast<ID3D11DeviceContext*>(runtimeData.context);
+
+        if (!hWnd && runtimeData.renderWindows && runtimeData.renderWindows->hWnd) {
+            hWnd = reinterpret_cast<HWND>(runtimeData.renderWindows->hWnd);
+            screenSize = renderManager->GetScreenSize();
+
+            static std::atomic<bool> input_handler_initialized = false;
+            bool expected_ih_init = false;
+
+            if (input_handler_initialized.compare_exchange_strong(expected_ih_init, true)) {
+                Initialize(hWnd, &ultralightThread, &views, &viewsMutex);
+
+                // Schedule WndProc hook installation on the main thread (required for
+                // SetWindowSubclass)
+                SKSE::GetTaskInterface()->AddTask([]() {
+                    if (InstallWndProcHook()) {
+                        logger::info("WndProc hook installed successfully.");
+                    } else {
+                        logger::error("Failed to install WndProc hook!");
+                    }
+                });
+            }
+        } else if (!hWnd) {
+            logger::warn("InitGraphics: Could not obtain HWND.");
+        }
+
+        if (d3dDevice && d3dContext) {
+            if (!commonStates || !spriteBatch) {
+                try {
+                    commonStates = std::make_unique<DirectX::CommonStates>(d3dDevice);
+                    spriteBatch = std::make_unique<DirectX::SpriteBatch>(d3dContext);
+                    logger::info("DirectXTK SpriteBatch and CommonStates (re)initialized.");
+                } catch (const std::exception& e) {
+                    logger::critical("Failed to initialize DirectXTK: {}", e.what());
+                    commonStates.reset();
+                    spriteBatch.reset();
+                }
+            }
+
+            if (!cursorTexture && d3dDevice) {
+                auto cursorPath = Utils::GetBasePath() / "misc" / "cursor.png";
+                HRESULT hr =
+                    DirectX::CreateWICTextureFromFile(d3dDevice, cursorPath.wstring().c_str(), nullptr, &cursorTexture);
+                if (SUCCEEDED(hr)) {
+                    logger::info("Cursor texture loaded successfully.");
+                } else {
+                    logger::error("Failed to load cursor texture from '{}'. HRESULT: 0x{:08X}", cursorPath.string(),
+                                  static_cast<unsigned int>(hr));
+                    cursorTexture.Reset();
+                }
+            }
+        } else {
+            logger::error("Cannot initialize DirectXTK: D3D device or context is null.");
+            commonStates.reset();
+            spriteBatch.reset();
+        }
+    }
+
+    void D3DPresent(uint32_t a_p1) {
+        RealD3dPresentFunc(a_p1);
+
+        if (!coreInitialized || rendererInitFailed) return;
+
+        if (!d3dDevice || !d3dContext || !spriteBatch || !commonStates || !hWnd || screenSize.width == 0) {
+            InitGraphics();
+            if (!d3dDevice || !d3dContext || !spriteBatch || !commonStates || !hWnd || screenSize.width == 0) return;
+        }
+
+        std::vector<PrismaViewId> viewsWithPendingRelease;
+        {
+            std::shared_lock lock(viewsMutex);
+            for (const auto& pair : views) {
+                if (pair.second && pair.second->pendingResourceRelease.load()) {
+                    viewsWithPendingRelease.push_back(pair.first);
+                }
+            }
+        }
+
+        for (const auto& viewId : viewsWithPendingRelease) {
+            std::shared_ptr<PrismaView> viewData = nullptr;
+            {
+                std::shared_lock lock(viewsMutex);
+                auto it = views.find(viewId);
+                if (it != views.end()) {
+                    viewData = it->second;
+                }
+            }
+
+            if (viewData) {
+                logger::debug(
+                    "D3DPresent: Releasing D3D resources for View [{}] from render "
+                    "thread",
+                    viewId);
+                ViewRenderer::ReleaseViewTexture(viewData.get());
+                Inspector::ReleaseInspectorTexture(viewData.get());
+                viewData->pendingResourceRelease = false;
+            }
+        }
+
+        // Process pending operations for all views
+        ViewOperationQueue::ProcessAllViewOperations();
+
+        auto ultralightFuture = ultralightThread.submit([dev = d3dDevice, ctx = d3dContext, hwnd = hWnd]() {
+            // Enable SEH to C++ exception translation for this thread (only needs to be
+            // set once per thread)
+            static bool sehTranslatorSet = false;
+            if (!sehTranslatorSet) {
+                _set_se_translator(SEHTranslator);
+                sehTranslatorSet = true;
+            }
+
+            try {
+                if (!dev || !ctx || !hwnd) {
+                    logger::warn("UI Thread: D3D device/context/hwnd is null, skipping frame.");
+                    return;
+                }
+
+                // Capture renderer locally to avoid race with shutdown
+                auto localRenderer = renderer;
+                if (!localRenderer) {
+                    logger::warn("UI Thread: Renderer is null, skipping frame.");
+                    return;
+                }
+
+                // Check for views that need recovery after an exception
+                std::vector<std::shared_ptr<PrismaView>> viewsToRecover;
+                {
+                    std::shared_lock lock(viewsMutex);
+                    for (auto& pair : views) {
+                        if (pair.second && pair.second->needsRecovery.load() && pair.second->ultralightView) {
+                            viewsToRecover.push_back(pair.second);
+                        }
+                    }
+                }
+
+                for (auto& viewData : viewsToRecover) {
+                    int attempts = viewData->recoveryAttempts.fetch_add(1);
+                    if (attempts >= 3) {
+                        logger::error(
+                            "UI Thread: View [{}] recovery failed after {} attempts, giving "
+                            "up",
+                            viewData->id, attempts);
+                        viewData->needsRecovery = false;
+                        continue;
+                    }
+
+                    // Use original URL for recovery (the entry point that sets up
+                    // everything)
+                    if (!viewData->originalUrl.empty()) {
+                        logger::info(
+                            "UI Thread: Recovering View [{}] (attempt {}) by reloading "
+                            "original URL: {}",
+                            viewData->id, attempts + 1, viewData->originalUrl);
+                        try {
+                            viewData->ultralightView->LoadURL(String(viewData->originalUrl.c_str()));
+                            viewData->needsRecovery = false;
+                            viewData->isLoadingFinished = false;
+                            // recoveryAttempts will be reset by OnFinishLoading on successful
+                            // load
+                        } catch (...) {
+                            logger::error("UI Thread: Failed to initiate recovery for View [{}]", viewData->id);
+                        }
+                    } else {
+                        logger::warn("UI Thread: View [{}] needs recovery but has no originalUrl", viewData->id);
+                        viewData->needsRecovery = false;  // Clear flag to avoid infinite loop
+                    }
+                }
+
+                std::vector<std::shared_ptr<PrismaView>> viewsToInitialize;
+                {
+                    std::shared_lock lock(viewsMutex);
+                    for (auto& pair : views) {
+                        if (pair.second && !pair.second->ultralightView && !pair.second->htmlPathToLoad.empty()) {
+                            viewsToInitialize.push_back(pair.second);
+                        }
+                    }
+                }
+
+                for (auto& viewData : viewsToInitialize) {
+                    if (!viewData || viewData->ultralightView) continue;
+
+                    logger::info("UI Thread: Creating View [{}] for path: {}", viewData->id, viewData->htmlPathToLoad);
+
+                    if (screenSize.width == 0 || screenSize.height == 0) {
+                        logger::error("UI Thread: Cannot create View [{}], screen size is zero.", viewData->id);
+                        continue;
+                    }
+
+                    // Re-check renderer before creating view
+                    if (!localRenderer) {
+                        logger::warn("UI Thread: Renderer became null during view creation.");
+                        break;
+                    }
+
+                    ViewConfig view_config;
+                    view_config.is_accelerated = false;
+                    view_config.is_transparent = true;
+                    view_config.initial_focus = false;
+                    view_config.enable_images = true;
+                    view_config.enable_javascript = true;
+                    view_config.enable_compositor = false;
+
+                    viewData->ultralightView =
+                        localRenderer->CreateView(screenSize.width, screenSize.height, view_config, nullptr);
+
+                    if (viewData->ultralightView) {
+                        viewData->loadListener = std::make_unique<Listeners::MyLoadListener>(viewData->id);
+                        viewData->viewListener = std::make_unique<Listeners::MyViewListener>(viewData->id);
+                        viewData->ultralightView->set_load_listener(viewData->loadListener.get());
+                        viewData->ultralightView->set_view_listener(viewData->viewListener.get());
+                        viewData->ultralightView->LoadURL(String(viewData->htmlPathToLoad.c_str()));
+                        viewData->ultralightView->Unfocus();
+                        viewData->htmlPathToLoad.clear();
+                        logger::info("UI Thread: View [{}] successfully created and loading URL.", viewData->id);
+                    } else {
+                        logger::error("UI Thread: Failed to create Ultralight View for ID [{}].", viewData->id);
+                        viewData->htmlPathToLoad = "[CREATION FAILED]";
+                    }
+                }
+
+                ProcessEvents();
+
+                if (localRenderer) {
+                    localRenderer->Update();
+                    localRenderer->RefreshDisplay(0);
+                    localRenderer->Render();
+                }
+
+                RenderViews();
+            } catch (const SEHException& seh) {
+                logger::critical("UI Thread: SEH Exception in render loop: {} at address 0x{:p}", seh.details(),
+                                 seh.address());
+                // Mark all views for recovery - the renderer state is likely corrupted
+                {
+                    std::shared_lock lock(viewsMutex);
+                    for (auto& pair : views) {
+                        if (pair.second) {
+                            pair.second->needsRecovery = true;
+                            logger::warn("View [{}] marked for recovery after SEH exception", pair.first);
+                        }
+                    }
+                }
+            } catch (const std::exception& e) {
+                logger::critical("UI Thread: Exception in render loop: {}", e.what());
+                // Mark all views for recovery
+                {
+                    std::shared_lock lock(viewsMutex);
+                    for (auto& pair : views) {
+                        if (pair.second) {
+                            pair.second->needsRecovery = true;
+                        }
+                    }
+                }
+            } catch (...) {
+                // Unknown exceptions (likely from Ultralight/WebCore internals)
+                logger::critical(
+                    "UI Thread: Unknown exception in render loop (likely Ultralight "
+                    "internal error)");
+                // Mark all views for recovery
+                {
+                    std::shared_lock lock(viewsMutex);
+                    for (auto& pair : views) {
+                        if (pair.second) {
+                            pair.second->needsRecovery = true;
+                        }
+                    }
+                }
+            }
+        });
+
+        // Wait for UI thread but handle any exceptions that might have escaped
         try {
-          Platform& plat = Platform::instance();
-          ultralightLogger = std::make_unique<MyUltralightLogger>();
-          plat.set_logger(ultralightLogger.get());
-          plat.set_font_loader(ultralight::GetPlatformFontLoader());
-
-          plat.set_file_system(
-              ultralight::GetPlatformFileSystem(basePath.string().c_str()));
-
-          Config config;
-          config.resource_path_prefix = "resources/";
-          plat.set_config(config);
-
-          renderer = Renderer::Create();
-          if (!renderer) {
-            logger::critical("Failed to create Ultralight Renderer!");
-            rendererInitFailed = true;
-          } else {
-            logger::info(
-                "Ultralight Platform configured and Renderer created on UI "
-                "thread.");
-          }
+            ultralightFuture.get();
         } catch (const std::exception& e) {
-          logger::critical(
-              "Exception during Ultralight Platform/Renderer init on UI "
-              "thread: {}",
-              e.what());
-          rendererInitFailed = true;
+            logger::error("D3DPresent: Exception from UI thread: {}", e.what());
         } catch (...) {
-          logger::critical(
-              "Unknown exception during Ultralight Platform/Renderer init on "
-              "UI thread.");
-          rendererInitFailed = true;
+            logger::error("D3DPresent: Unknown exception from UI thread");
         }
-      })
-      .get();
 
-  auto ui = RE::UI::GetSingleton();
-  ui->Register(FocusMenu::MENU_NAME, FocusMenu::Creator);
-
-  logger::info("PrismaUI Core System Initialized.");
-}
-
-void InitHooks() {
-  logger::debug("Installing D3D Present hook...");
-  RealD3dPresentFunc = Hooks::D3DPresentHook::Install(&D3DPresent);
-  logger::info("D3D Present hook installed.");
-}
-
-void InitGraphics() {
-  auto* renderManager = RE::BSGraphics::Renderer::GetSingleton();
-  if (!renderManager) {
-    logger::critical("InitGraphics: RenderManager is null!");
-    return;
-  }
-  auto runtimeData = renderManager->GetRuntimeData();
-  if (!d3dDevice)
-    d3dDevice = reinterpret_cast<ID3D11Device*>(runtimeData.forwarder);
-  if (!d3dContext)
-    d3dContext = reinterpret_cast<ID3D11DeviceContext*>(runtimeData.context);
-
-  if (!hWnd && runtimeData.renderWindows && runtimeData.renderWindows->hWnd) {
-    hWnd = reinterpret_cast<HWND>(runtimeData.renderWindows->hWnd);
-    screenSize = renderManager->GetScreenSize();
-
-    static std::atomic<bool> input_handler_initialized = false;
-    bool expected_ih_init = false;
-
-    if (input_handler_initialized.compare_exchange_strong(expected_ih_init,
-                                                          true)) {
-      Initialize(hWnd, &ultralightThread, &views, &viewsMutex);
-
-      // Schedule WndProc hook installation on the main thread (required for
-      // SetWindowSubclass)
-      SKSE::GetTaskInterface()->AddTask([]() {
-        if (InstallWndProcHook()) {
-          logger::info("WndProc hook installed successfully.");
-        } else {
-          logger::error("Failed to install WndProc hook!");
+        std::vector<std::shared_ptr<PrismaView>> viewsToCheck;
+        {
+            std::shared_lock lock(viewsMutex);
+            viewsToCheck.reserve(views.size());
+            for (const auto& pair : views) {
+                if (pair.second && pair.second->ultralightView) {
+                    viewsToCheck.push_back(pair.second);
+                }
+            }
         }
-      });
-    }
-  } else if (!hWnd) {
-    logger::warn("InitGraphics: Could not obtain HWND.");
-  }
 
-  if (d3dDevice && d3dContext) {
-    if (!commonStates || !spriteBatch) {
-      try {
-        commonStates = std::make_unique<DirectX::CommonStates>(d3dDevice);
-        spriteBatch = std::make_unique<DirectX::SpriteBatch>(d3dContext);
-        logger::info("DirectXTK SpriteBatch and CommonStates (re)initialized.");
-      } catch (const std::exception& e) {
-        logger::critical("Failed to initialize DirectXTK: {}", e.what());
-        commonStates.reset();
-        spriteBatch.reset();
-      }
+        for (const auto& viewData : viewsToCheck) {
+            UpdateSingleTextureFromBuffer(viewData);
+        }
+
+        DrawViews();
+        DrawCursor();
     }
 
-    if (!cursorTexture && d3dDevice) {
-      auto cursorPath = Utils::GetBasePath() / "misc" / "cursor.png";
-      HRESULT hr = DirectX::CreateWICTextureFromFile(
-          d3dDevice, cursorPath.wstring().c_str(), nullptr, &cursorTexture);
-      if (SUCCEEDED(hr)) {
-        logger::info("Cursor texture loaded successfully.");
-      } else {
-        logger::error(
-            "Failed to load cursor texture from '{}'. HRESULT: 0x{:08X}",
-            cursorPath.string(), static_cast<unsigned int>(hr));
+    void Shutdown() {
+        logger::info("Shutting down PrismaUI Core System...");
+
+        std::vector<PrismaViewId> viewIdsToDestroy;
+        {
+            std::shared_lock lock(viewsMutex);
+            for (const auto& pair : views) {
+                viewIdsToDestroy.push_back(pair.first);
+            }
+        }
+
+        for (const auto& id : viewIdsToDestroy) {
+            try {
+                ViewManager::Destroy(id);
+            } catch (const std::exception& e) {
+                logger::error("Error destroying view [{}] during shutdown: {}", id, e.what());
+            }
+        }
+
         cursorTexture.Reset();
-      }
+        spriteBatch.reset();
+        commonStates.reset();
+        logger::debug("DirectXTK resources released.");
+
+        InputHandler::Shutdown();
+
+        d3dDevice = nullptr;
+        d3dContext = nullptr;
+        hWnd = nullptr;
+
+        {
+            std::unique_lock lock(viewsMutex);
+            views.clear();
+        }
+        if (renderer) {
+            // Move renderer to the lambda so it's the sole owner,
+            // ensuring release happens on the UI thread
+            ultralightThread
+                .submit([renderer_moved = std::move(renderer)]() mutable {
+                    logger::info("Releasing global renderer on UI thread.");
+                    renderer_moved = nullptr;
+                })
+                .get();
+        }
+
+        // Release Ultralight platform objects after renderer is destroyed
+        ultralightLogger.reset();
+
+        coreInitialized = false;
+        logger::info("PrismaUI Core System shut down complete.");
     }
-  } else {
-    logger::error(
-        "Cannot initialize DirectXTK: D3D device or context is null.");
-    commonStates.reset();
-    spriteBatch.reset();
-  }
-}
-
-void D3DPresent(uint32_t a_p1) {
-  RealD3dPresentFunc(a_p1);
-
-  if (!coreInitialized || rendererInitFailed) return;
-
-  if (!d3dDevice || !d3dContext || !spriteBatch || !commonStates || !hWnd ||
-      screenSize.width == 0) {
-    InitGraphics();
-    if (!d3dDevice || !d3dContext || !spriteBatch || !commonStates || !hWnd ||
-        screenSize.width == 0)
-      return;
-  }
-
-  std::vector<PrismaViewId> viewsWithPendingRelease;
-  {
-    std::shared_lock lock(viewsMutex);
-    for (const auto& pair : views) {
-      if (pair.second && pair.second->pendingResourceRelease.load()) {
-        viewsWithPendingRelease.push_back(pair.first);
-      }
-    }
-  }
-
-  for (const auto& viewId : viewsWithPendingRelease) {
-    std::shared_ptr<PrismaView> viewData = nullptr;
-    {
-      std::shared_lock lock(viewsMutex);
-      auto it = views.find(viewId);
-      if (it != views.end()) {
-        viewData = it->second;
-      }
-    }
-
-    if (viewData) {
-      logger::debug(
-          "D3DPresent: Releasing D3D resources for View [{}] from render "
-          "thread",
-          viewId);
-      ViewRenderer::ReleaseViewTexture(viewData.get());
-      Inspector::ReleaseInspectorTexture(viewData.get());
-      viewData->pendingResourceRelease = false;
-    }
-  }
-
-  // Process pending operations for all views
-  ViewOperationQueue::ProcessAllViewOperations();
-
-  auto ultralightFuture = ultralightThread.submit([dev = d3dDevice,
-                                                   ctx = d3dContext,
-                                                   hwnd = hWnd]() {
-    // Enable SEH to C++ exception translation for this thread (only needs to be
-    // set once per thread)
-    static bool sehTranslatorSet = false;
-    if (!sehTranslatorSet) {
-      _set_se_translator(SEHTranslator);
-      sehTranslatorSet = true;
-    }
-
-    try {
-      if (!dev || !ctx || !hwnd) {
-        logger::warn(
-            "UI Thread: D3D device/context/hwnd is null, skipping frame.");
-        return;
-      }
-
-      // Capture renderer locally to avoid race with shutdown
-      auto localRenderer = renderer;
-      if (!localRenderer) {
-        logger::warn("UI Thread: Renderer is null, skipping frame.");
-        return;
-      }
-
-      // Check for views that need recovery after an exception
-      std::vector<std::shared_ptr<PrismaView>> viewsToRecover;
-      {
-        std::shared_lock lock(viewsMutex);
-        for (auto& pair : views) {
-          if (pair.second && pair.second->needsRecovery.load() &&
-              pair.second->ultralightView) {
-            viewsToRecover.push_back(pair.second);
-          }
-        }
-      }
-
-      for (auto& viewData : viewsToRecover) {
-        int attempts = viewData->recoveryAttempts.fetch_add(1);
-        if (attempts >= 3) {
-          logger::error(
-              "UI Thread: View [{}] recovery failed after {} attempts, giving "
-              "up",
-              viewData->id, attempts);
-          viewData->needsRecovery = false;
-          continue;
-        }
-
-        // Use original URL for recovery (the entry point that sets up
-        // everything)
-        if (!viewData->originalUrl.empty()) {
-          logger::info(
-              "UI Thread: Recovering View [{}] (attempt {}) by reloading "
-              "original URL: {}",
-              viewData->id, attempts + 1, viewData->originalUrl);
-          try {
-            viewData->ultralightView->LoadURL(
-                String(viewData->originalUrl.c_str()));
-            viewData->needsRecovery = false;
-            viewData->isLoadingFinished = false;
-            // recoveryAttempts will be reset by OnFinishLoading on successful
-            // load
-          } catch (...) {
-            logger::error(
-                "UI Thread: Failed to initiate recovery for View [{}]",
-                viewData->id);
-          }
-        } else {
-          logger::warn(
-              "UI Thread: View [{}] needs recovery but has no originalUrl",
-              viewData->id);
-          viewData->needsRecovery = false;  // Clear flag to avoid infinite loop
-        }
-      }
-
-      std::vector<std::shared_ptr<PrismaView>> viewsToInitialize;
-      {
-        std::shared_lock lock(viewsMutex);
-        for (auto& pair : views) {
-          if (pair.second && !pair.second->ultralightView &&
-              !pair.second->htmlPathToLoad.empty()) {
-            viewsToInitialize.push_back(pair.second);
-          }
-        }
-      }
-
-      for (auto& viewData : viewsToInitialize) {
-        if (!viewData || viewData->ultralightView) continue;
-
-        logger::info("UI Thread: Creating View [{}] for path: {}", viewData->id,
-                     viewData->htmlPathToLoad);
-
-        if (screenSize.width == 0 || screenSize.height == 0) {
-          logger::error(
-              "UI Thread: Cannot create View [{}], screen size is zero.",
-              viewData->id);
-          continue;
-        }
-
-        // Re-check renderer before creating view
-        if (!localRenderer) {
-          logger::warn("UI Thread: Renderer became null during view creation.");
-          break;
-        }
-
-        ViewConfig view_config;
-        view_config.is_accelerated = false;
-        view_config.is_transparent = true;
-        view_config.initial_focus = false;
-        view_config.enable_images = true;
-        view_config.enable_javascript = true;
-        view_config.enable_compositor = false;
-
-        viewData->ultralightView = localRenderer->CreateView(
-            screenSize.width, screenSize.height, view_config, nullptr);
-
-        if (viewData->ultralightView) {
-          viewData->loadListener =
-              std::make_unique<Listeners::MyLoadListener>(viewData->id);
-          viewData->viewListener =
-              std::make_unique<Listeners::MyViewListener>(viewData->id);
-          viewData->ultralightView->set_load_listener(
-              viewData->loadListener.get());
-          viewData->ultralightView->set_view_listener(
-              viewData->viewListener.get());
-          viewData->ultralightView->LoadURL(
-              String(viewData->htmlPathToLoad.c_str()));
-          viewData->ultralightView->Unfocus();
-          viewData->htmlPathToLoad.clear();
-          logger::info(
-              "UI Thread: View [{}] successfully created and loading URL.",
-              viewData->id);
-        } else {
-          logger::error(
-              "UI Thread: Failed to create Ultralight View for ID [{}].",
-              viewData->id);
-          viewData->htmlPathToLoad = "[CREATION FAILED]";
-        }
-      }
-
-      ProcessEvents();
-
-      if (localRenderer) {
-        localRenderer->Update();
-        localRenderer->RefreshDisplay(0);
-        localRenderer->Render();
-      }
-
-      RenderViews();
-    } catch (const SEHException& seh) {
-      logger::critical(
-          "UI Thread: SEH Exception in render loop: {} at address 0x{:p}",
-          seh.details(), seh.address());
-      // Mark all views for recovery - the renderer state is likely corrupted
-      {
-        std::shared_lock lock(viewsMutex);
-        for (auto& pair : views) {
-          if (pair.second) {
-            pair.second->needsRecovery = true;
-            logger::warn("View [{}] marked for recovery after SEH exception",
-                         pair.first);
-          }
-        }
-      }
-    } catch (const std::exception& e) {
-      logger::critical("UI Thread: Exception in render loop: {}", e.what());
-      // Mark all views for recovery
-      {
-        std::shared_lock lock(viewsMutex);
-        for (auto& pair : views) {
-          if (pair.second) {
-            pair.second->needsRecovery = true;
-          }
-        }
-      }
-    } catch (...) {
-      // Unknown exceptions (likely from Ultralight/WebCore internals)
-      logger::critical(
-          "UI Thread: Unknown exception in render loop (likely Ultralight "
-          "internal error)");
-      // Mark all views for recovery
-      {
-        std::shared_lock lock(viewsMutex);
-        for (auto& pair : views) {
-          if (pair.second) {
-            pair.second->needsRecovery = true;
-          }
-        }
-      }
-    }
-  });
-
-  // Wait for UI thread but handle any exceptions that might have escaped
-  try {
-    ultralightFuture.get();
-  } catch (const std::exception& e) {
-    logger::error("D3DPresent: Exception from UI thread: {}", e.what());
-  } catch (...) {
-    logger::error("D3DPresent: Unknown exception from UI thread");
-  }
-
-  std::vector<std::shared_ptr<PrismaView>> viewsToCheck;
-  {
-    std::shared_lock lock(viewsMutex);
-    viewsToCheck.reserve(views.size());
-    for (const auto& pair : views) {
-      if (pair.second && pair.second->ultralightView) {
-        viewsToCheck.push_back(pair.second);
-      }
-    }
-  }
-
-  for (const auto& viewData : viewsToCheck) {
-    UpdateSingleTextureFromBuffer(viewData);
-  }
-
-  DrawViews();
-  DrawCursor();
-}
-
-void Shutdown() {
-  logger::info("Shutting down PrismaUI Core System...");
-
-  std::vector<PrismaViewId> viewIdsToDestroy;
-  {
-    std::shared_lock lock(viewsMutex);
-    for (const auto& pair : views) {
-      viewIdsToDestroy.push_back(pair.first);
-    }
-  }
-
-  for (const auto& id : viewIdsToDestroy) {
-    try {
-      ViewManager::Destroy(id);
-    } catch (const std::exception& e) {
-      logger::error("Error destroying view [{}] during shutdown: {}", id,
-                    e.what());
-    }
-  }
-
-  cursorTexture.Reset();
-  spriteBatch.reset();
-  commonStates.reset();
-  logger::debug("DirectXTK resources released.");
-
-  InputHandler::Shutdown();
-
-  d3dDevice = nullptr;
-  d3dContext = nullptr;
-  hWnd = nullptr;
-
-  {
-    std::unique_lock lock(viewsMutex);
-    views.clear();
-  }
-  if (renderer) {
-    // Move renderer to the lambda so it's the sole owner,
-    // ensuring release happens on the UI thread
-    ultralightThread
-        .submit([renderer_moved = std::move(renderer)]() mutable {
-          logger::info("Releasing global renderer on UI thread.");
-          renderer_moved = nullptr;
-        })
-        .get();
-  }
-
-  // Release Ultralight platform objects after renderer is destroyed
-  ultralightLogger.reset();
-
-  coreInitialized = false;
-  logger::info("PrismaUI Core System shut down complete.");
-}
 }  // namespace PrismaUI::Core

--- a/src/PrismaUI/Core.h
+++ b/src/PrismaUI/Core.h
@@ -112,7 +112,6 @@ namespace PrismaUI::Core {
 	extern ID3D11Device* d3dDevice;
 	extern ID3D11DeviceContext* d3dContext;
 	extern HWND hWnd;
-	extern WNDPROC s_originalWndProc;
 	extern RE::BSGraphics::ScreenSize screenSize;
 	extern std::unique_ptr<DirectX::SpriteBatch> spriteBatch;
 	extern std::unique_ptr<DirectX::CommonStates> commonStates;

--- a/src/PrismaUI/Core.h
+++ b/src/PrismaUI/Core.h
@@ -49,6 +49,8 @@ namespace PrismaUI::Core {
 		RefPtr<View> ultralightView = nullptr;
 		RefPtr<View> inspectorView = nullptr;
 		std::string htmlPathToLoad;
+		std::string originalUrl;       // Original URL from view creation (for recovery)
+		std::string lastLoadedUrl;     // Track last successfully loaded URL
 		std::atomic<bool> isHidden = false;
 		std::unique_ptr<Listeners::MyLoadListener> loadListener;
 		std::unique_ptr<Listeners::MyViewListener> viewListener;
@@ -58,6 +60,8 @@ namespace PrismaUI::Core {
 		std::atomic<bool> isPaused = false;
 		int order = 0;
 		std::atomic<bool> inspectorVisible = false;
+		std::atomic<bool> needsRecovery = false;  // Flag for recovery after exception
+		std::atomic<int> recoveryAttempts = 0;    // Track recovery attempts to prevent loops
 
 		// Inspector rendering data
 		std::vector<std::byte> inspectorPixelBuffer;
@@ -108,6 +112,7 @@ namespace PrismaUI::Core {
 	extern ID3D11Device* d3dDevice;
 	extern ID3D11DeviceContext* d3dContext;
 	extern HWND hWnd;
+	extern WNDPROC s_originalWndProc;
 	extern RE::BSGraphics::ScreenSize screenSize;
 	extern std::unique_ptr<DirectX::SpriteBatch> spriteBatch;
 	extern std::unique_ptr<DirectX::CommonStates> commonStates;

--- a/src/PrismaUI/InputHandler.cpp
+++ b/src/PrismaUI/InputHandler.cpp
@@ -28,29 +28,8 @@ namespace PrismaUI::InputHandler {
 
     // WndProc subclass state
     static std::atomic<bool> g_wndProcInstalled = false;
-    static std::atomic<bool> g_commonControlsInit = false;
     static constexpr UINT_PTR SUBCLASS_ID = 0x505249534D41; // "PRISMA" in hex
     static std::mutex g_wndProcMutex;  // Thread-safe installation
-
-    bool EnsureCommonControlsInitialized()
-    {
-        if (g_commonControlsInit.load()) {
-            return true;
-        }
-
-        INITCOMMONCONTROLSEX icc = {};
-        icc.dwSize = sizeof(icc);
-        icc.dwICC = ICC_STANDARD_CLASSES;
-
-        if (InitCommonControlsEx(&icc)) {
-            g_commonControlsInit.store(true);
-            logger::debug("Common controls initialized");
-            return true;
-        }
-
-        logger::warn("Failed to initialize common controls: {}", GetLastError());
-        return false;
-    }
 
     class MouseEventListener : public RE::BSTEventSink<RE::InputEvent*> {
     public:
@@ -309,9 +288,6 @@ namespace PrismaUI::InputHandler {
 
         logger::info("PrismaUI::InputHandler Initialized with HWND: {}", (void*)g_hWnd);
 
-        // Initialize Common Controls early (required for SetWindowSubclass)
-        EnsureCommonControlsInitialized();
-
         auto inputEventSource = RE::BSInputDeviceManager::GetSingleton();
         if (inputEventSource) {
             inputEventSource->AddEventSink(MouseEventListener::GetSingleton());
@@ -339,11 +315,6 @@ namespace PrismaUI::InputHandler {
         if (!IsWindow(g_hWnd)) {
             logger::error("HWND {:p} is not a valid window", (void*)g_hWnd);
             return false;
-        }
-
-        // Initialize Common Controls (required for SetWindowSubclass)
-        if (!EnsureCommonControlsInitialized()) {
-            logger::warn("Common controls initialization failed, trying subclass anyway...");
         }
 
         logger::debug("Attempting to install subclass on HWND: {:p}", (void*)g_hWnd);

--- a/src/PrismaUI/InputHandler.cpp
+++ b/src/PrismaUI/InputHandler.cpp
@@ -156,7 +156,7 @@ namespace PrismaUI::InputHandler {
         }
     };
 
-    LRESULT CALLBACK SubclassProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam, UINT_PTR uIdSubclass, DWORD_PTR dwRefData) {
+    LRESULT CALLBACK SubclassProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam, UINT_PTR uIdSubclass, DWORD_PTR /*dwRefData*/) {
         if (g_isAnyInputCaptureActive.load()) {
             bool handledByUI = false;
             Core::PrismaViewId focusedViewIdCopy;

--- a/src/PrismaUI/Listeners.cpp
+++ b/src/PrismaUI/Listeners.cpp
@@ -1,113 +1,144 @@
 ﻿#include "Listeners.h"
-#include "Core.h"
+
 #include "Communication.h"
+#include "Core.h"
 
 namespace PrismaUI::Listeners {
-	using namespace Core;
-	using namespace Communication;
+using namespace Core;
+using namespace Communication;
 
-	// MyLoadListener
-	MyLoadListener::MyLoadListener(Core::PrismaViewId id) : viewId_(std::move(id)) {}
+// MyLoadListener
+MyLoadListener::MyLoadListener(Core::PrismaViewId id)
+    : viewId_(std::move(id)) {}
 
-	MyLoadListener::~MyLoadListener() = default;
+MyLoadListener::~MyLoadListener() = default;
 
-	void MyLoadListener::OnBeginLoading(View* caller, uint64_t frame_id, bool is_main_frame, const String& url) {
-		logger::info("View [{}]: LoadListener: Begin loading URL: {}", viewId_, url.utf8().data());
-		ultralightThread.submit([id = viewId_] {
-			std::shared_lock lock(viewsMutex);
-			auto it = views.find(id);
-			if (it != views.end()) {
-				it->second->isLoadingFinished = false;
-			}
-		});
-	}
-
-	void MyLoadListener::OnFinishLoading(View* caller, uint64_t frame_id, bool is_main_frame, const String& url) {
-		logger::info("View [{}]: LoadListener: Finished loading URL: {}", viewId_, url.utf8().data());
-		ultralightThread.submit([id = viewId_, urlStr = std::string(url.utf8().data())] {
-			std::shared_lock lock(viewsMutex);
-			auto it = views.find(id);
-			if (it != views.end()) {
-				it->second->isLoadingFinished = true;
-				it->second->lastLoadedUrl = urlStr;  // Track for recovery
-				it->second->recoveryAttempts = 0;    // Reset recovery counter on successful load
-				Communication::BindJSCallbacks(id);
-			}
-		});
-	}
-
-	void MyLoadListener::OnFailLoading(View* caller, uint64_t frame_id, bool is_main_frame, const String& url, const String& description, const String& error_domain, int error_code) {
-		logger::error("View [{}]: LoadListener: Failed loading URL: {}. Error: {}", viewId_, url.utf8().data(), description.utf8().data());
-		ultralightThread.submit([id = viewId_] {
-			std::shared_lock lock(viewsMutex);
-			auto it = views.find(id);
-			if (it != views.end()) {
-				it->second->isLoadingFinished = false;
-			}
-		});
-	}
-
-	void MyLoadListener::OnWindowObjectReady(View* caller, uint64_t frame_id, bool is_main_frame, const String& url) {
-		logger::info("View [{}]: LoadListener: Window object ready.", viewId_);
-	}
-
-	void MyLoadListener::OnDOMReady(View* caller, uint64_t frame_id, bool is_main_frame, const String& url) {
-		logger::info("View [{}]: LoadListener: DOM ready.", viewId_);
-		ultralightThread.submit([id = viewId_] {
-			std::shared_lock lock(viewsMutex);
-			auto it = views.find(id);
-			if (it != views.end() && it->second->domReadyCallback) {
-				it->second->domReadyCallback(id);
-			}
-		});
-	}
-
-	// MyViewListener
-	MyViewListener::MyViewListener(Core::PrismaViewId id) : viewId_(std::move(id)) {}
-
-	MyViewListener::~MyViewListener() = default;
-
-	void MyViewListener::OnAddConsoleMessage(View* caller, const ConsoleMessage& message) {
-		logger::info("View [{}]: JSConsole: {}", viewId_, message.message().utf8().data());
-	}
-
-	RefPtr<View> MyViewListener::OnCreateInspectorView(View* caller, bool is_local, const String& inspectedURL) {
-		logger::info("View [{}]: ViewListener: OnCreateInspectorView called (is_local={}, URL={})", 
-			viewId_, is_local, inspectedURL.utf8().data());
-
-		RefPtr<View> inspectorView = nullptr;
-
-		std::unique_lock lock(viewsMutex);
-		auto it = views.find(viewId_);
-		if (it != views.end() && it->second) {
-			auto viewData = it->second;
-
-			if (!viewData->inspectorView && viewData->ultralightView && renderer) {
-				uint32_t width = viewData->inspectorDisplayWidth > 0 ? viewData->inspectorDisplayWidth : 800;
-				uint32_t height = viewData->inspectorDisplayHeight > 0 ? viewData->inspectorDisplayHeight : 600;
-
-				ViewConfig config;
-				config.is_accelerated = false;
-				config.is_transparent = true;
-
-				viewData->inspectorView = renderer->CreateView(width, height, config, nullptr);
-				inspectorView = viewData->inspectorView;
-
-				logger::info("View [{}]: Inspector view created with size {}x{}", viewId_, width, height);
-			}
-			else if (viewData->inspectorView) {
-				inspectorView = viewData->inspectorView;
-				logger::info("View [{}]: Returning existing inspector view", viewId_);
-			}
-		}
-
-		return inspectorView;
-	}
-
-	// MyUltralightLogger
-	MyUltralightLogger::~MyUltralightLogger() = default;
-
-	void MyUltralightLogger::LogMessage(LogLevel log_level, const String& message) {
-		// Implementation was empty, so keep it empty.
-	}
+void MyLoadListener::OnBeginLoading(View* /*caller*/, uint64_t /*frame_id*/,
+                                    bool /*is_main_frame*/, const String& url) {
+  logger::info("View [{}]: LoadListener: Begin loading URL: {}", viewId_,
+               url.utf8().data());
+  ultralightThread.submit([id = viewId_] {
+    std::shared_lock lock(viewsMutex);
+    auto it = views.find(id);
+    if (it != views.end()) {
+      it->second->isLoadingFinished = false;
+    }
+  });
 }
+
+void MyLoadListener::OnFinishLoading(View* /*caller*/, uint64_t /*frame_id*/,
+                                     bool /*is_main_frame*/,
+                                     const String& url) {
+  logger::info("View [{}]: LoadListener: Finished loading URL: {}", viewId_,
+               url.utf8().data());
+  ultralightThread.submit(
+      [id = viewId_, urlStr = std::string(url.utf8().data())] {
+        std::shared_lock lock(viewsMutex);
+        auto it = views.find(id);
+        if (it != views.end()) {
+          it->second->isLoadingFinished = true;
+          it->second->lastLoadedUrl = urlStr;  // Track for recovery
+          it->second->recoveryAttempts =
+              0;  // Reset recovery counter on successful load
+          Communication::BindJSCallbacks(id);
+        }
+      });
+}
+
+void MyLoadListener::OnFailLoading(View* /*caller*/, uint64_t /*frame_id*/,
+                                   bool /*is_main_frame*/, const String& url,
+                                   const String& description,
+                                   const String& /*error_domain*/,
+                                   int /*error_code*/) {
+  logger::error("View [{}]: LoadListener: Failed loading URL: {}. Error: {}",
+                viewId_, url.utf8().data(), description.utf8().data());
+  ultralightThread.submit([id = viewId_] {
+    std::shared_lock lock(viewsMutex);
+    auto it = views.find(id);
+    if (it != views.end()) {
+      it->second->isLoadingFinished = false;
+    }
+  });
+}
+
+void MyLoadListener::OnWindowObjectReady(View* /*caller*/,
+                                         uint64_t /*frame_id*/,
+                                         bool /*is_main_frame*/,
+                                         const String& /*url*/) {
+  logger::info("View [{}]: LoadListener: Window object ready.", viewId_);
+}
+
+void MyLoadListener::OnDOMReady(View* /*caller*/, uint64_t /*frame_id*/,
+                                bool /*is_main_frame*/, const String& /*url*/) {
+  logger::info("View [{}]: LoadListener: DOM ready.", viewId_);
+  ultralightThread.submit([id = viewId_] {
+    std::shared_lock lock(viewsMutex);
+    auto it = views.find(id);
+    if (it != views.end() && it->second->domReadyCallback) {
+      it->second->domReadyCallback(id);
+    }
+  });
+}
+
+// MyViewListener
+MyViewListener::MyViewListener(Core::PrismaViewId id)
+    : viewId_(std::move(id)) {}
+
+MyViewListener::~MyViewListener() = default;
+
+void MyViewListener::OnAddConsoleMessage(View* /*caller*/,
+                                         const ConsoleMessage& message) {
+  logger::info("View [{}]: JSConsole: {}", viewId_,
+               message.message().utf8().data());
+}
+
+RefPtr<View> MyViewListener::OnCreateInspectorView(View* /*caller*/,
+                                                   bool is_local,
+                                                   const String& inspectedURL) {
+  logger::info(
+      "View [{}]: ViewListener: OnCreateInspectorView called (is_local={}, "
+      "URL={})",
+      viewId_, is_local, inspectedURL.utf8().data());
+
+  RefPtr<View> inspectorView = nullptr;
+
+  std::unique_lock lock(viewsMutex);
+  auto it = views.find(viewId_);
+  if (it != views.end() && it->second) {
+    auto viewData = it->second;
+
+    if (!viewData->inspectorView && viewData->ultralightView && renderer) {
+      uint32_t width = viewData->inspectorDisplayWidth > 0
+                           ? viewData->inspectorDisplayWidth
+                           : 800;
+      uint32_t height = viewData->inspectorDisplayHeight > 0
+                            ? viewData->inspectorDisplayHeight
+                            : 600;
+
+      ViewConfig config;
+      config.is_accelerated = false;
+      config.is_transparent = true;
+
+      viewData->inspectorView =
+          renderer->CreateView(width, height, config, nullptr);
+      inspectorView = viewData->inspectorView;
+
+      logger::info("View [{}]: Inspector view created with size {}x{}", viewId_,
+                   width, height);
+    } else if (viewData->inspectorView) {
+      inspectorView = viewData->inspectorView;
+      logger::info("View [{}]: Returning existing inspector view", viewId_);
+    }
+  }
+
+  return inspectorView;
+}
+
+// MyUltralightLogger
+MyUltralightLogger::~MyUltralightLogger() = default;
+
+void MyUltralightLogger::LogMessage(LogLevel /*log_level*/,
+                                    const String& /*message*/) {
+  // Implementation was empty, so keep it empty.
+}
+}  // namespace PrismaUI::Listeners

--- a/src/PrismaUI/Listeners.cpp
+++ b/src/PrismaUI/Listeners.cpp
@@ -24,11 +24,13 @@ namespace PrismaUI::Listeners {
 
 	void MyLoadListener::OnFinishLoading(View* caller, uint64_t frame_id, bool is_main_frame, const String& url) {
 		logger::info("View [{}]: LoadListener: Finished loading URL: {}", viewId_, url.utf8().data());
-		ultralightThread.submit([id = viewId_] {
+		ultralightThread.submit([id = viewId_, urlStr = std::string(url.utf8().data())] {
 			std::shared_lock lock(viewsMutex);
 			auto it = views.find(id);
 			if (it != views.end()) {
 				it->second->isLoadingFinished = true;
+				it->second->lastLoadedUrl = urlStr;  // Track for recovery
+				it->second->recoveryAttempts = 0;    // Reset recovery counter on successful load
 				Communication::BindJSCallbacks(id);
 			}
 		});

--- a/src/PrismaUI/ViewManager.cpp
+++ b/src/PrismaUI/ViewManager.cpp
@@ -37,6 +37,7 @@ namespace PrismaUI::ViewManager {
 		viewData->id = newViewId;
 		viewData->ultralightView = nullptr;
 		viewData->htmlPathToLoad = fileUrl;
+		viewData->originalUrl = fileUrl;  // Store for recovery after exceptions
 		viewData->isHidden = false;
 		viewData->domReadyCallback = onDomReadyCallback;
 

--- a/src/PrismaUI/ViewRenderer.cpp
+++ b/src/PrismaUI/ViewRenderer.cpp
@@ -19,8 +19,13 @@ namespace PrismaUI::ViewRenderer {
 			std::shared_lock lock(viewsMutex);
 			viewsToRender.reserve(views.size());
 			for (const auto& pair : views) {
-				if (pair.second && !pair.second->isHidden) {
-					viewsToRender.push_back(pair.second);
+				const auto& viewPtr = pair.second;
+				if (!viewPtr) {
+					logger::warn("RenderViews: Found null shared_ptr in views map for ID [{}]", pair.first);
+					continue;
+				}
+				if (!viewPtr->isHidden.load()) {
+					viewsToRender.push_back(viewPtr);
 				}
 			}
 		}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,7 +22,9 @@ SKSEPlugin_Load(const SKSE::LoadInterface *a_skse) {
 
   logger::info("---------------- {} {} by {} ----------------", SKSE::GetPluginName(), SKSE::GetPluginVersion(), SKSE::GetPluginAuthor());
   logger::info("-------------------- Docs and Guides: https://prismaui.dev -------------------");
-  
+  logger::info("------------------- built using CommonLibSSE-NG v{} -------------------", COMMONLIBSSE_VERSION);
+  logger::info("------------------- Running on Skyrim v{} -------------------", REL::Module::get().version().string());
+
   // Load Ultralight DLLs from Data/PrismaUI/libs before any Ultralight API usage
   if (!PrismaUI::Utils::DllLoader::GetSingleton().LoadUltralightLibraries()) {
     logger::critical("Failed to load Ultralight libraries! Plugin will not load.");


### PR DESCRIPTION
possible though rare crash found in Ultralight view
Added SEH to catch Windows exceptions  in the Ultralight thread.

if Ultralight view crash is detected the view is reloaded.
log entries will be like:
```
[2026-01-28 07:20:48.285] [critical] [12376] [Core.cpp:452] UI Thread: SEH Exception in render loop: Access Violation (read at 0x000000007FFFFFFF) at address 0x0x7ff963c4d636
[2026-01-28 07:20:48.285] [warning] [12376] [Core.cpp:461] View [8046108081039410948] marked for recovery after SEH exception
[2026-01-28 07:20:48.287] [info] [12376] [Core.cpp:353] UI Thread: Recovering View [8046108081039410948] (attempt 1) by reloading original URL: file:///views/PluginNameI/index.html
[2026-01-28 07:20:48.287] [info] [12376] [Listeners.cpp:73] View [8046108081039410948]: LoadListener: DOM ready.
```