### PR TITLE
Commonlib update 4.2.0 "da5dd61"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ set(CMAKE_JOB_POOL_COMPILE compile)
 set(CMAKE_JOB_POOL_LINK link)
 set(CMAKE_INSTALL_MESSAGE LAZY)
 
-project(PrismaUI VERSION 1.3.0 LANGUAGES CXX)
+project(PrismaUI VERSION 1.3.1 LANGUAGES CXX)
 
 # Set build root for external builds
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")

--- a/cmake/commonlibsse.cmake
+++ b/cmake/commonlibsse.cmake
@@ -4,21 +4,11 @@
 set(CommonLibPath "external/commonlibsse-ng")
 set(CommonLibName "CommonLibSSE")
 
-# Read CommonLibSSE version from vcpkg.json
-set(COMMONLIB_VCPKG_JSON_PATH "${CMAKE_SOURCE_DIR}/${CommonLibPath}/vcpkg.json")
-if(NOT EXISTS "${COMMONLIB_VCPKG_JSON_PATH}")
-    message(FATAL_ERROR
-        "CommonLibSSE-NG vcpkg.json not found at \"${COMMONLIB_VCPKG_JSON_PATH}\". "
-        "Ensure the CommonLibSSE-NG submodule is checked out and includes vcpkg.json with a \"version-semver\" field.")
-endif()
-file(READ "${COMMONLIB_VCPKG_JSON_PATH}" COMMONLIB_VCPKG_JSON_CONTENT)
-string(JSON COMMONLIBSSE_VERSION ERROR_VARIABLE _COMMONLIBSSE_VERSION_JSON_ERROR GET "${COMMONLIB_VCPKG_JSON_CONTENT}" "version-semver")
-if(_COMMONLIBSSE_VERSION_JSON_ERROR)
-    message(FATAL_ERROR
-        "Failed to extract \"version-semver\" from \"${COMMONLIB_VCPKG_JSON_PATH}\": ${_COMMONLIBSSE_VERSION_JSON_ERROR}")
-endif()
+# Extract version from CommonLibSSE's CMakeLists.txt (project() VERSION doesn't propagate to parent scope)
+file(READ "${CMAKE_SOURCE_DIR}/${CommonLibPath}/CMakeLists.txt" _commonlib_cmakelists_content)
+string(REGEX MATCH "VERSION[ \t]+([0-9]+\\.[0-9]+\\.[0-9]+)" _ "${_commonlib_cmakelists_content}")
+set(COMMONLIBSSE_VERSION "${CMAKE_MATCH_1}" CACHE STRING "CommonLibSSE-NG version" FORCE)
 message(STATUS "Configuring CommonLibSSE-NG version ${COMMONLIBSSE_VERSION}")
-set(COMMONLIBSSE_VERSION "${COMMONLIBSSE_VERSION}" CACHE STRING "CommonLibSSE-NG version" FORCE)
 
 # Save original build type
 set(_saved_build_type "${CMAKE_BUILD_TYPE}")

--- a/src/PrismaUI/ViewManager.cpp
+++ b/src/PrismaUI/ViewManager.cpp
@@ -88,13 +88,13 @@ namespace PrismaUI::ViewManager {
         }
 
         auto controlMap = RE::ControlMap::GetSingleton();
-        controlMap->ToggleControls(RE::UserEvents::USER_EVENT_FLAG::kWheelZoom, true);
-        controlMap->ToggleControls(RE::UserEvents::USER_EVENT_FLAG::kLooking, true);
-        controlMap->ToggleControls(RE::UserEvents::USER_EVENT_FLAG::kJumping, true);
-        controlMap->ToggleControls(RE::UserEvents::USER_EVENT_FLAG::kMovement, true);
-        controlMap->ToggleControls(RE::UserEvents::USER_EVENT_FLAG::kActivate, true);
-        controlMap->ToggleControls(RE::UserEvents::USER_EVENT_FLAG::kPOVSwitch, true);
-        controlMap->ToggleControls(RE::UserEvents::USER_EVENT_FLAG::kVATS, true);
+        controlMap->ToggleControls(RE::UserEvents::USER_EVENT_FLAG::kWheelZoom, true, false);
+        controlMap->ToggleControls(RE::UserEvents::USER_EVENT_FLAG::kLooking, true, false);
+        controlMap->ToggleControls(RE::UserEvents::USER_EVENT_FLAG::kJumping, true, false);
+        controlMap->ToggleControls(RE::UserEvents::USER_EVENT_FLAG::kMovement, true, false);
+        controlMap->ToggleControls(RE::UserEvents::USER_EVENT_FLAG::kActivate, true, false);
+        controlMap->ToggleControls(RE::UserEvents::USER_EVENT_FLAG::kPOVSwitch, true, false);
+        controlMap->ToggleControls(RE::UserEvents::USER_EVENT_FLAG::kVATS, true, false);
     }
 
     void Show(const Core::PrismaViewId& viewId) {
@@ -244,13 +244,13 @@ namespace PrismaUI::ViewManager {
             }
 
             auto controlMap = RE::ControlMap::GetSingleton();
-            controlMap->ToggleControls(RE::UserEvents::USER_EVENT_FLAG::kWheelZoom, false);
-            controlMap->ToggleControls(RE::UserEvents::USER_EVENT_FLAG::kLooking, false);
-            controlMap->ToggleControls(RE::UserEvents::USER_EVENT_FLAG::kJumping, false);
-            controlMap->ToggleControls(RE::UserEvents::USER_EVENT_FLAG::kMovement, false);
-            controlMap->ToggleControls(RE::UserEvents::USER_EVENT_FLAG::kActivate, false);
-            controlMap->ToggleControls(RE::UserEvents::USER_EVENT_FLAG::kPOVSwitch, false);
-            controlMap->ToggleControls(RE::UserEvents::USER_EVENT_FLAG::kVATS, false);
+            controlMap->ToggleControls(RE::UserEvents::USER_EVENT_FLAG::kWheelZoom, false, false);
+            controlMap->ToggleControls(RE::UserEvents::USER_EVENT_FLAG::kLooking, false, false);
+            controlMap->ToggleControls(RE::UserEvents::USER_EVENT_FLAG::kJumping, false, false);
+            controlMap->ToggleControls(RE::UserEvents::USER_EVENT_FLAG::kMovement, false, false);
+            controlMap->ToggleControls(RE::UserEvents::USER_EVENT_FLAG::kActivate, false, false);
+            controlMap->ToggleControls(RE::UserEvents::USER_EVENT_FLAG::kPOVSwitch, false, false);
+            controlMap->ToggleControls(RE::UserEvents::USER_EVENT_FLAG::kVATS, false, false);
 
             if (pauseGame) {
                 auto ui = RE::UI::GetSingleton();


### PR DESCRIPTION
IMenu issue resolved in Commonlib. 

As PrismaUI manages its own focus/unfocus lifecycle and symmetrically enables/disables controls, the new ToggleControls() a_storeState is set to false to avoid interfering with other systems that may rely on the store/restore mechanism.

Run:
`git submodule update --init --recursive`

No issues noted with "1.6.1170" or "1.5.97".

CommonLib upstream IMenu reversion:
https://github.com/powerof3/CommonLibSSE/pull/199 and https://github.com/alandtse/CommonLibVR/pull/119