### PR TITLE
feat: add RegisterConsoleCallback; add api verson check method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ compile_commands.json
 /release/
 /dist/
 external/ultralight-free-sdk-1.4.1-dev-win-x64.7z
+Build_Config_Local.ps1

--- a/BuildRelease.ps1
+++ b/BuildRelease.ps1
@@ -3,13 +3,22 @@ param(
     [int]$threads = 8
 )
 
+$vsDevShellPath = "C:/Program Files/Microsoft Visual Studio/2022/Professional/Common7/Tools/Launch-VsDevShell.ps1"
+# Load in template default variables
+if (Test-Path .\Build_Config_Template.ps1) {
+    . .\Build_Config_Template.ps1
+}
+# Load in local variable overrides
+if (Test-Path .\Build_Config_Local.ps1) {
+    . .\Build_Config_Local.ps1
+}
 
-Write-Host "Running preset $preset"
 
 # Save current directory, launch VS dev shell, and return to original directory
-$vsDevShellPath = "C:/Program Files/Microsoft Visual Studio/2022/Community/Common7/Tools/Launch-VsDevShell.ps1"
 $currentDirectory = $PWD.Path
 & $vsDevShellPath -Arch amd64; Set-Location -Path "${currentDirectory}"
+
+Write-Host "Running preset $preset"
 
 # Build cmake configure arguments
 $cmakeArgs = @("-S", ".", "--preset=$preset", "-DCMAKE_COMPILE_JOBS=$threads", "-Wno-dev")

--- a/BuildRelease.ps1
+++ b/BuildRelease.ps1
@@ -4,11 +4,9 @@ param(
 )
 
 $vsDevShellPath = "C:/Program Files/Microsoft Visual Studio/2022/Professional/Common7/Tools/Launch-VsDevShell.ps1"
-# Load in template default variables
-if (Test-Path .\Build_Config_Template.ps1) {
-    . .\Build_Config_Template.ps1
-}
+
 # Load in local variable overrides
+# local developer copy of Build_Config_Template.ps1 to override $vsDevShellPath or other variables if needed
 if (Test-Path .\Build_Config_Local.ps1) {
     . .\Build_Config_Local.ps1
 }

--- a/Build_Config_Template.ps1
+++ b/Build_Config_Template.ps1
@@ -1,0 +1,4 @@
+# Use as a template
+# Copy to "Build_Config_Local.ps1"
+
+$vsDevShellPath =  "W:/Program Files/Microsoft Visual Studio/2022/Community/Common7/Tools/Launch-VsDevShell.ps1"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 4.1)
+cmake_minimum_required(VERSION 3.21)
 
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -18,7 +18,7 @@ set(CMAKE_JOB_POOL_COMPILE compile)
 set(CMAKE_JOB_POOL_LINK link)
 set(CMAKE_INSTALL_MESSAGE LAZY)
 
-project(PrismaUI VERSION 1.3.0 LANGUAGES CXX)
+project(PrismaUI VERSION 1.3.1 LANGUAGES CXX)
 
 # Set build root for external builds
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")

--- a/UpdateExternalDeps.ps1
+++ b/UpdateExternalDeps.ps1
@@ -1,0 +1,156 @@
+# Download and extract external dependencies if they don't exist
+
+$ErrorActionPreference = "Stop"
+
+# Define dependencies
+$dependencies = @(  
+
+)
+
+# Ensure external directory exists
+$externalDir = Join-Path -Path $PSScriptRoot -ChildPath "external"
+if (-not (Test-Path $externalDir)) {
+    Write-Host "Creating external directory..." -ForegroundColor Yellow
+    New-Item -ItemType Directory -Path $externalDir | Out-Null
+}
+
+# Process each dependency
+foreach ($dep in $dependencies) {
+    $targetPath = Join-Path $externalDir $dep.Name
+    
+    if (Test-Path $targetPath) {
+        Write-Host " $($dep.Name) already exists, skipping..." -ForegroundColor Green
+        continue
+    }
+    
+    Write-Host "Downloading $($dep.Name)..." -ForegroundColor Cyan
+    $archiveName = Split-Path $dep.Url -Leaf
+    $archivePath = Join-Path $externalDir $archiveName
+    
+    try {
+        # Download the file
+        Invoke-WebRequest -Uri $dep.Url -OutFile $archivePath -UseBasicParsing
+        Write-Host "  Downloaded to $archivePath" -ForegroundColor Gray
+        
+        # Extract based on archive type
+        Write-Host "Extracting $archiveName..." -ForegroundColor Cyan
+        
+        if ($dep.ArchiveType -eq "zip") {
+            # Extract ZIP file
+            Expand-Archive -Path $archivePath -DestinationPath $externalDir -Force
+            Write-Host "  Extracted $($dep.Name)" -ForegroundColor Green
+        }
+        elseif ($dep.ArchiveType -eq "tar.bz2") {
+            # Extract tar.bz2 file using tar (available in Windows 10+)
+            $originalLocation = Get-Location
+            Set-Location $externalDir
+            tar -xjf $archivePath
+            Set-Location $originalLocation
+            Write-Host "  Extracted $($dep.Name)" -ForegroundColor Green
+        }
+        
+        # Clean up archive file
+        Remove-Item $archivePath -Force
+        Write-Host "  Cleaned up archive file" -ForegroundColor Gray
+        
+        }
+        catch {
+        Write-Host " Error processing $($dep.Name): $_" -ForegroundColor Red
+        if (Test-Path $archivePath) {
+            Remove-Item $archivePath -Force -ErrorAction SilentlyContinue
+        }
+        throw
+    }
+}
+
+# =============================================================================
+# Git Submodule Setup
+# =============================================================================
+# Handles first-time submodule init after pull, standalone clones that need
+# converting, and stale .git/modules cache entries.
+
+Write-Host "`nChecking git submodules..." -ForegroundColor Cyan
+
+$gitmodulesPath = Join-Path $PSScriptRoot ".gitmodules"
+if (Test-Path $gitmodulesPath) {
+    $gitmodulesContent = Get-Content $gitmodulesPath -Raw
+
+    # Parse [submodule] blocks for path and name
+    $submoduleBlocks = [regex]::Matches($gitmodulesContent,
+        '(?ms)\[submodule\s+"([^"]+)"\].*?path\s*=\s*(\S+)')
+
+    foreach ($block in $submoduleBlocks) {
+        $subName = $block.Groups[1].Value
+        $subPath = $block.Groups[2].Value
+        $fullPath = Join-Path $PSScriptRoot $subPath
+        $gitEntry = Join-Path $fullPath ".git"
+
+        Write-Host "  Submodule: $subPath" -ForegroundColor Gray
+
+        if (-not (Test-Path $fullPath)) {
+            Write-Host "    Not yet created, will initialize." -ForegroundColor Yellow
+        }
+        elseif (Test-Path $gitEntry -PathType Leaf) {
+            # .git is a file pointing to the parent repo's modules dir -- correct
+            Write-Host "    OK (proper submodule reference)" -ForegroundColor Green
+        }
+        elseif (Test-Path $gitEntry -PathType Container) {
+            # .git is a directory -- this is a standalone clone, not a submodule
+            Write-Host "    Standalone git clone detected at submodule path." -ForegroundColor Yellow
+            Write-Host "    Removing so it can be re-initialized as a submodule..." -ForegroundColor Yellow
+            Remove-Item -Recurse -Force $fullPath
+        }
+        elseif ((Get-ChildItem $fullPath -Force | Measure-Object).Count -gt 0) {
+            # Directory has content but no .git at all
+            Write-Host "    Non-empty directory blocking submodule init." -ForegroundColor Yellow
+            Write-Host "    Removing so it can be re-initialized as a submodule..." -ForegroundColor Yellow
+            Remove-Item -Recurse -Force $fullPath
+        }
+        else {
+            Write-Host "    Empty directory, will be populated during init." -ForegroundColor Yellow
+        }
+
+        # Check for stale .git/modules cache that can block re-init
+        $moduleCachePath = Join-Path -Path $PSScriptRoot -ChildPath ".git\modules\$subName"
+        if ((Test-Path $moduleCachePath) -and -not (Test-Path $gitEntry -PathType Leaf)) {
+            Write-Host "    Clearing stale .git/modules/$subName cache..." -ForegroundColor Yellow
+            Remove-Item -Recurse -Force $moduleCachePath
+        }
+    }
+}
+
+try {
+    Write-Host "`nInitializing and updating submodules..." -ForegroundColor Cyan
+    git submodule update --init --recursive
+    if ($LASTEXITCODE -ne 0) {
+        throw "git submodule update --init --recursive failed (exit code $LASTEXITCODE)"
+    }
+    Write-Host " Git submodules updated successfully." -ForegroundColor Green
+
+    # Verify final state
+    $subStatus = git submodule status
+    foreach ($line in $subStatus) {
+        $line = $line.Trim()
+        if ($line -match '^\-') {
+            Write-Host "  WARN  $line" -ForegroundColor Yellow
+        }
+        elseif ($line -match '^\+') {
+            Write-Host "  NOTE  $line  (commit differs from index)" -ForegroundColor Yellow
+        }
+        else {
+            Write-Host "  OK    $line" -ForegroundColor Green
+        }
+    }
+}
+catch {
+    Write-Host " Error updating git submodules: $_" -ForegroundColor Red
+    throw
+}
+
+Write-Host "`nSubmodules and external dependencies are ready!" -ForegroundColor Green
+
+$ultraLightArchive = "ultralight-free-sdk-1.4.1-dev-win-x64.7z"
+if (-not (Test-Path (Join-Path $externalDir $ultraLightArchive))) {
+    Write-Host "`n $ultraLightArchive not found in $externalDir. Download it from https://ultralig.ht/download" -ForegroundColor Yellow
+}
+

--- a/UpdateExternalDeps.ps1
+++ b/UpdateExternalDeps.ps1
@@ -93,6 +93,13 @@ if (Test-Path $gitmodulesPath) {
         elseif (Test-Path $gitEntry -PathType Leaf) {
             # .git is a file pointing to the parent repo's modules dir -- correct
             Write-Host "    OK (proper submodule reference)" -ForegroundColor Green
+            # Clean untracked files and reset modifications so checkout can succeed
+            Write-Host "    Cleaning working tree..." -ForegroundColor Gray
+            $savedEAP = $ErrorActionPreference
+            $ErrorActionPreference = 'SilentlyContinue'
+            git -C $fullPath clean -ffd
+            git -C $fullPath checkout .
+            $ErrorActionPreference = $savedEAP
         }
         elseif (Test-Path $gitEntry -PathType Container) {
             # .git is a directory -- this is a standalone clone, not a submodule

--- a/src/API/API.cpp
+++ b/src/API/API.cpp
@@ -222,3 +222,21 @@ bool PluginAPI::PrismaUIInterface::HasAnyActiveFocus() noexcept
 {
 	return PrismaUI::ViewManager::HasAnyActiveFocus();
 }
+
+void PluginAPI::PrismaUIInterface::RegisterConsoleCallback(PrismaView view, PRISMA_UI_API::ConsoleMessageCallback callback) noexcept
+{
+	if (!view) {
+		return;
+	}
+
+	if (callback) {
+		auto wrappedCallback = [callback](PrismaUI::Core::PrismaViewId id, PRISMA_UI_API::ConsoleMessageLevel level, const std::string& msg) {
+			SKSE::GetTaskInterface()->AddTask([callback, id, level, msg]() {
+				callback(id, level, msg.c_str());
+			});
+		};
+		PrismaUI::ViewManager::RegisterConsoleCallback(view, wrappedCallback);
+	} else {
+		PrismaUI::ViewManager::RegisterConsoleCallback(view, nullptr);
+	}
+}

--- a/src/API/API.h
+++ b/src/API/API.h
@@ -1,13 +1,13 @@
-﻿#pragma once
+#pragma once
 
 #include "PrismaUI_API.h"
 
 class PluginAPI
 {
-	using InterfaceVersion1 = PRISMA_UI_API::IVPrismaUI1;
+	using LatestInterface = PRISMA_UI_API::IVPrismaUI2;
 
 public:
-	class PrismaUIInterface : public InterfaceVersion1
+	class PrismaUIInterface : public LatestInterface
 	{
 	private:
 		PrismaUIInterface() noexcept {};
@@ -20,7 +20,7 @@ public:
 			return std::addressof(singleton);
 		}
 
-		// InterfaceVersion1
+		// IVPrismaUI1 (order needs to match PrismaUI_API.h exactly for correct vtable layout)
 
 		virtual PrismaView CreateView(const char* htmlPath, PRISMA_UI_API::OnDomReadyCallback onDomReadyCallback = nullptr) noexcept override;
 		virtual void Invoke(PrismaView view, const char* script, PRISMA_UI_API::JSCallback callback = nullptr) noexcept override;
@@ -38,16 +38,15 @@ public:
 		virtual void Destroy(PrismaView view) noexcept override;
 		virtual void SetOrder(PrismaView view, int order) noexcept override;
 		virtual int GetOrder(PrismaView view) noexcept override;
-		virtual bool HasAnyActiveFocus() noexcept override;
-
-		// Console message callback
-		virtual void RegisterConsoleCallback(PrismaView view, PRISMA_UI_API::ConsoleMessageCallback callback) noexcept override;
-
-		// Inspector methods
 		virtual void CreateInspectorView(PrismaView view) noexcept override;
 		virtual void SetInspectorVisibility(PrismaView view, bool visible) noexcept override;
 		virtual bool IsInspectorVisible(PrismaView view) noexcept override;
 		virtual void SetInspectorBounds(PrismaView view, float topLeftX, float topLeftY, unsigned int width, unsigned int height) noexcept override;
+		virtual bool HasAnyActiveFocus() noexcept override;
+
+		// IVPrismaUI2
+
+		virtual void RegisterConsoleCallback(PrismaView view, PRISMA_UI_API::ConsoleMessageCallback callback) noexcept override;
 
 	private:
 		unsigned long apiTID = 0;

--- a/src/API/API.h
+++ b/src/API/API.h
@@ -40,6 +40,9 @@ public:
 		virtual int GetOrder(PrismaView view) noexcept override;
 		virtual bool HasAnyActiveFocus() noexcept override;
 
+		// Console message callback
+		virtual void RegisterConsoleCallback(PrismaView view, PRISMA_UI_API::ConsoleMessageCallback callback) noexcept override;
+
 		// Inspector methods
 		virtual void CreateInspectorView(PrismaView view) noexcept override;
 		virtual void SetInspectorVisibility(PrismaView view, bool visible) noexcept override;

--- a/src/PrismaUI/Core.h
+++ b/src/PrismaUI/Core.h
@@ -35,6 +35,10 @@
 #include "Utils/NanoID.h"
 #include "Utils/SingleThreadExecutor.h"
 
+namespace PRISMA_UI_API {
+    enum class ConsoleMessageLevel : uint8_t;
+}
+
 namespace PrismaUI::Listeners {
     class MyLoadListener;
     class MyViewListener;
@@ -57,6 +61,7 @@ namespace PrismaUI::Core {
         std::unique_ptr<Listeners::MyViewListener> viewListener;
         std::atomic<bool> isLoadingFinished = false;
         std::function<void(const PrismaViewId&)> domReadyCallback;
+        std::function<void(PrismaViewId, PRISMA_UI_API::ConsoleMessageLevel, const std::string&)> consoleMessageCallback;
         int scrollingPixelSize = 28;
         std::atomic<bool> isPaused = false;
         int order = 0;

--- a/src/PrismaUI/Listeners.cpp
+++ b/src/PrismaUI/Listeners.cpp
@@ -2,6 +2,7 @@
 
 #include "Communication.h"
 #include "Core.h"
+#include "PrismaUI_API.h"
 
 namespace PrismaUI::Listeners {
     using namespace Core;
@@ -75,6 +76,23 @@ namespace PrismaUI::Listeners {
 
     void MyViewListener::OnAddConsoleMessage(View* /*caller*/, const ConsoleMessage& message) {
         // logger::info("View [{}]: JSConsole: {}", viewId_, message.message().utf8().data());
+        std::shared_lock lock(viewsMutex);
+        auto it = views.find(viewId_);
+        if (it != views.end() && it->second && it->second->consoleMessageCallback) {
+            PRISMA_UI_API::ConsoleMessageLevel level = PRISMA_UI_API::ConsoleMessageLevel::Log;
+            switch (message.level()) {
+                case kMessageLevel_Warning: level = PRISMA_UI_API::ConsoleMessageLevel::Warning; break;
+                case kMessageLevel_Error:   level = PRISMA_UI_API::ConsoleMessageLevel::Error; break;
+                case kMessageLevel_Debug:   level = PRISMA_UI_API::ConsoleMessageLevel::Debug; break;
+                case kMessageLevel_Info:    level = PRISMA_UI_API::ConsoleMessageLevel::Info; break;
+                default: break;
+            }
+            auto msg = std::string(message.message().utf8().data());
+            auto cb = it->second->consoleMessageCallback;
+            auto id = viewId_;
+            lock.unlock();
+            cb(id, level, msg);
+        }
     }
 
     RefPtr<View> MyViewListener::OnCreateInspectorView(View* /*caller*/, bool is_local, const String& inspectedURL) {

--- a/src/PrismaUI/ViewManager.cpp
+++ b/src/PrismaUI/ViewManager.cpp
@@ -607,4 +607,15 @@ namespace PrismaUI::ViewManager {
             return false;
         }
     }
+
+    void RegisterConsoleCallback(const Core::PrismaViewId& viewId,
+                                 std::function<void(Core::PrismaViewId, PRISMA_UI_API::ConsoleMessageLevel, const std::string&)> callback) {
+        std::unique_lock lock(viewsMutex);
+        auto it = views.find(viewId);
+        if (it != views.end() && it->second) {
+            it->second->consoleMessageCallback = std::move(callback);
+        } else {
+            logger::warn("RegisterConsoleCallback: View ID [{}] not found.", viewId);
+        }
+    }
 }

--- a/src/PrismaUI/ViewManager.h
+++ b/src/PrismaUI/ViewManager.h
@@ -1,5 +1,8 @@
 ﻿#pragma once
 
+#include <cstdint>
+#include <functional>
+
 #pragma warning(push)
 #pragma warning(disable : 4100)
 #include <AppCore/Platform.h>
@@ -8,6 +11,10 @@
 #include <Ultralight/Ultralight.h>
 #include <Ultralight/View.h>
 #pragma warning(pop)
+
+namespace PRISMA_UI_API {
+    enum class ConsoleMessageLevel : uint8_t;
+}
 
 namespace PrismaUI::Core {
     typedef uint64_t PrismaViewId;
@@ -39,4 +46,8 @@ namespace PrismaUI::ViewManager {
     void SetInspectorBounds(const Core::PrismaViewId& viewId, float topLeftX, float topLeftY, uint32_t width,
                             uint32_t height);
     bool HasAnyActiveFocus();
+
+    // Console message callback registration
+    void RegisterConsoleCallback(const Core::PrismaViewId& viewId,
+                                 std::function<void(Core::PrismaViewId, PRISMA_UI_API::ConsoleMessageLevel, const std::string&)> callback);
 }

--- a/src/PrismaUI_API.h
+++ b/src/PrismaUI_API.h
@@ -1,118 +1,155 @@
 ﻿/*
-* For modders: Copy this file into your own project if you wish to use this API.
-*/
+ * For modders: Copy this file into your own project if you wish to use this API.
+ */
 #pragma once
 
-#include <functional>
-#include <queue>
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+
+#include <Windows.h>
 #include <stdint.h>
+
+#include <functional>
 #include <iostream>
+#include <queue>
 
 typedef uint64_t PrismaView;
 
-namespace PRISMA_UI_API
-{
-	constexpr const auto PrismaUIPluginName = "PrismaUI";
+namespace PRISMA_UI_API {
+    constexpr const auto PrismaUIPluginName = "PrismaUI";
 
-	using PluginHandle = SKSE::PluginHandle;
-	using ActorHandle = RE::ActorHandle;
+    enum class InterfaceVersion : uint8_t { V1 };
 
-	enum class InterfaceVersion : uint8_t
-	{
-		V1
-	};
+    typedef void (*OnDomReadyCallback)(PrismaView view);
+    typedef void (*JSCallback)(const char* result);
+    typedef void (*JSListenerCallback)(const char* argument);
 
-	typedef void (*OnDomReadyCallback)(PrismaView view);
-	typedef void (*JSCallback)(const char* result);
-	typedef void (*JSListenerCallback)(const char* argument);
+    // JavaScript console message severity level.
+    enum class ConsoleMessageLevel : uint8_t { Log = 0, Warning, Error, Debug, Info };
 
-	// PrismaUI modder interface v1
-	class IVPrismaUI1
-	{
-	public:
-		// Create view.
-		virtual PrismaView CreateView(const char* htmlPath, OnDomReadyCallback onDomReadyCallback = nullptr) noexcept = 0;
+    // Console message callback.
+    typedef void (*ConsoleMessageCallback)(PrismaView view, ConsoleMessageLevel level, const char* message);
 
-		// Send JS code to UI.
-		virtual void Invoke(PrismaView view, const char* script, JSCallback callback = nullptr) noexcept = 0;
+    // PrismaUI modder interface v1
+    class IVPrismaUI1 {
+    public:
+        // Create view.
+        virtual PrismaView CreateView(const char* htmlPath,
+                                      OnDomReadyCallback onDomReadyCallback = nullptr) noexcept = 0;
 
-		// Call JS function through JS Interop API (best performance).
-		virtual void InteropCall(PrismaView view, const char* functionName, const char* argument) noexcept = 0;
+        // Send JS code to UI.
+        virtual void Invoke(PrismaView view, const char* script, JSCallback callback = nullptr) noexcept = 0;
 
-		// Register JS listener.
-		virtual void RegisterJSListener(PrismaView view, const char* functionName, JSListenerCallback callback) noexcept = 0;
+        // Call JS function through JS Interop API (best performance).
+        virtual void InteropCall(PrismaView view, const char* functionName, const char* argument) noexcept = 0;
 
-		// Returns true if view has focus.
-		virtual bool HasFocus(PrismaView view) noexcept = 0;
+        // Register JS listener.
+        virtual void RegisterJSListener(PrismaView view, const char* functionName,
+                                        JSListenerCallback callback) noexcept = 0;
 
-		// Set focus on view.
-		virtual bool Focus(PrismaView view, bool pauseGame = false, bool disableFocusMenu = false) noexcept = 0;
+        // Returns true if view has focus.
+        virtual bool HasFocus(PrismaView view) noexcept = 0;
 
-		// Remove focus from view.
-		virtual void Unfocus(PrismaView view) noexcept = 0;
+        // Set focus on view.
+        virtual bool Focus(PrismaView view, bool pauseGame = false, bool disableFocusMenu = false) noexcept = 0;
 
-		// Show a hidden view.
-		virtual void Show(PrismaView view) noexcept = 0;
+        // Remove focus from view.
+        virtual void Unfocus(PrismaView view) noexcept = 0;
 
-		// Hide a visible view.
-		virtual void Hide(PrismaView view) noexcept = 0;
+        // Show a hidden view.
+        virtual void Show(PrismaView view) noexcept = 0;
 
-		// Returns true if view is hidden.
-		virtual bool IsHidden(PrismaView view) noexcept = 0;
+        // Hide a visible view.
+        virtual void Hide(PrismaView view) noexcept = 0;
 
-		// Get scroll size in pixels.
-		virtual int GetScrollingPixelSize(PrismaView view) noexcept = 0;
+        // Returns true if view is hidden.
+        virtual bool IsHidden(PrismaView view) noexcept = 0;
 
-		// Set scroll size in pixels.
-		virtual void SetScrollingPixelSize(PrismaView view, int pixelSize) noexcept = 0;
+        // Get scroll size in pixels.
+        virtual int GetScrollingPixelSize(PrismaView view) noexcept = 0;
 
-		// Returns true if view exists.
-		virtual bool IsValid(PrismaView view) noexcept = 0;
+        // Set scroll size in pixels.
+        virtual void SetScrollingPixelSize(PrismaView view, int pixelSize) noexcept = 0;
 
-		// Completely destroy view.
-		virtual void Destroy(PrismaView view) noexcept = 0;
+        // Returns true if view exists.
+        virtual bool IsValid(PrismaView view) noexcept = 0;
 
-		// Set view order.
-		virtual void SetOrder(PrismaView view, int order) noexcept = 0;
+        // Completely destroy view.
+        virtual void Destroy(PrismaView view) noexcept = 0;
 
-		// Get view order.
-		virtual int GetOrder(PrismaView view) noexcept = 0;
+        // Set view order.
+        virtual void SetOrder(PrismaView view, int order) noexcept = 0;
 
-		// Create inspector view for debugging.
-		virtual void CreateInspectorView(PrismaView view) noexcept = 0;
+        // Get view order.
+        virtual int GetOrder(PrismaView view) noexcept = 0;
 
-		// Show or hide the inspector overlay.
-		virtual void SetInspectorVisibility(PrismaView view, bool visible) noexcept = 0;
+        // Create inspector view for debugging.
+        virtual void CreateInspectorView(PrismaView view) noexcept = 0;
 
-		// Returns true if inspector is visible.
-		virtual bool IsInspectorVisible(PrismaView view) noexcept = 0;
+        // Show or hide the inspector overlay.
+        virtual void SetInspectorVisibility(PrismaView view, bool visible) noexcept = 0;
 
-		// Set inspector window position and size.
-		virtual void SetInspectorBounds(PrismaView view, float topLeftX, float topLeftY, unsigned int width, unsigned int height) noexcept = 0;
+        // Returns true if inspector is visible.
+        virtual bool IsInspectorVisible(PrismaView view) noexcept = 0;
 
-		// Returns true if any view has active focus.
-		virtual bool HasAnyActiveFocus() noexcept = 0;
-	};
+        // Set inspector window position and size.
+        virtual void SetInspectorBounds(PrismaView view, float topLeftX, float topLeftY, unsigned int width,
+                                        unsigned int height) noexcept = 0;
 
-	typedef void* (*_RequestPluginAPI)(const InterfaceVersion interfaceVersion);
+        // Returns true if any view has active focus.
+        virtual bool HasAnyActiveFocus() noexcept = 0;
 
+        // Register a callback to receive JavaScript console messages from a view.
+        // Pass nullptr to unregister.
+        virtual void RegisterConsoleCallback(PrismaView view, ConsoleMessageCallback callback) noexcept = 0;
+    };
 
-	/// Request the PrismaUI API interface.
-	/// Recommended: Send your request during or after SKSEMessagingInterface::kMessage_PostLoad to make sure the dll has already been loaded
+    typedef void* (*_RequestPluginAPI)(InterfaceVersion interfaceVersion);
 
-	[[nodiscard]] inline void* RequestPluginAPI(const InterfaceVersion a_interfaceVersion = InterfaceVersion::V1)
-	{
-		auto pluginHandle = GetModuleHandle(L"PrismaUI.dll"); // if you're getting the wchar error then just replace it by `GetModuleHandle("PrismaUI.dll");`
-		if (!pluginHandle) {
-			return nullptr;
-		}
+    // API version history:
+    //   1 = Original API (CreateView through HasAnyActiveFocus)
+    //   2 = Added RegisterConsoleCallback
+    typedef uint32_t (*_GetPrismaUIAPIVersion)();
 
-		_RequestPluginAPI requestAPIFunction = (_RequestPluginAPI)GetProcAddress(pluginHandle, "RequestPluginAPI");
+    /// Returns the API version supported by the loaded PrismaUI DLL.
+    /// Returns 0 if the function is not exported (i.e., DLL is older than version tracking).
+    [[nodiscard]] inline uint32_t GetAPIVersion() {
+        auto pluginHandle = GetModuleHandle(L"PrismaUI.dll");
+        if (!pluginHandle) {
+            return 0;
+        }
 
-		if (requestAPIFunction) {
-			return requestAPIFunction(a_interfaceVersion);
-		}
+        auto getVersion =
+            reinterpret_cast<_GetPrismaUIAPIVersion>(GetProcAddress(pluginHandle, "GetPrismaUIAPIVersion"));
+        if (getVersion) {
+            return getVersion();
+        }
 
-		return nullptr;
-	}
+        // DLL exists but doesn't export GetPrismaUIAPIVersion — it's version 1
+        return 1;
+    }
+
+    /// Request the PrismaUI API interface.
+    /// Recommended: Send your request during or after SKSEMessagingInterface::kMessage_PostLoad to make sure the dll
+    /// has already been loaded
+
+    [[nodiscard]] inline void* RequestPluginAPI(InterfaceVersion a_interfaceVersion = InterfaceVersion::V1) {
+        auto pluginHandle = GetModuleHandle(L"PrismaUI.dll");
+        if (!pluginHandle) {
+            return nullptr;
+        }
+
+        auto requestAPIFunction = reinterpret_cast<_RequestPluginAPI>(GetProcAddress(pluginHandle, "RequestPluginAPI"));
+
+        if (requestAPIFunction) {
+            return requestAPIFunction(a_interfaceVersion);
+        }
+
+        return nullptr;
+    }
 }

--- a/src/PrismaUI_API.h
+++ b/src/PrismaUI_API.h
@@ -4,32 +4,29 @@
 #pragma once
 
 #ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
+    #define WIN32_LEAN_AND_MEAN
 #endif
 
 #ifndef NOMINMAX
-#define NOMINMAX
+    #define NOMINMAX
 #endif
 
 #include <Windows.h>
 #include <stdint.h>
-
-#include <functional>
-#include <iostream>
-#include <queue>
 
 typedef uint64_t PrismaView;
 
 namespace PRISMA_UI_API {
     constexpr const auto PrismaUIPluginName = "PrismaUI";
 
-    enum class InterfaceVersion : uint8_t { V1 };
+    // Available PrismaUI interface versions
+    enum class InterfaceVersion : uint8_t { V1, V2 };
 
     typedef void (*OnDomReadyCallback)(PrismaView view);
     typedef void (*JSCallback)(const char* result);
     typedef void (*JSListenerCallback)(const char* argument);
 
-    // JavaScript console message severity level.
+    // JavaScript console message severity level for use with RegisterConsoleCallback().
     enum class ConsoleMessageLevel : uint8_t { Log = 0, Warning, Error, Debug, Info };
 
     // Console message callback.
@@ -37,6 +34,9 @@ namespace PRISMA_UI_API {
 
     // PrismaUI modder interface v1
     class IVPrismaUI1 {
+    protected:
+        ~IVPrismaUI1() = default;
+
     public:
         // Create view.
         virtual PrismaView CreateView(const char* htmlPath,
@@ -103,53 +103,63 @@ namespace PRISMA_UI_API {
 
         // Returns true if any view has active focus.
         virtual bool HasAnyActiveFocus() noexcept = 0;
+    };
 
+    // PrismaUI modder interface v2 (extends v1)
+    class IVPrismaUI2 : public IVPrismaUI1 {
+    protected:
+        ~IVPrismaUI2() = default;
+
+    public:
         // Register a callback to receive JavaScript console messages from a view.
         // Pass nullptr to unregister.
         virtual void RegisterConsoleCallback(PrismaView view, ConsoleMessageCallback callback) noexcept = 0;
     };
 
-    typedef void* (*_RequestPluginAPI)(InterfaceVersion interfaceVersion);
+    // Maps interface types to InterfaceVersion enum values.
+    // compile-time constraint -- only request interface versions that actually exist.
+    template <typename T>
+    struct InterfaceVersionMap;
 
-    // API version history:
-    //   1 = Original API (CreateView through HasAnyActiveFocus)
-    //   2 = Added RegisterConsoleCallback
-    typedef uint32_t (*_GetPrismaUIAPIVersion)();
+    template <>
+    struct InterfaceVersionMap<IVPrismaUI1> {
+        static constexpr InterfaceVersion version = InterfaceVersion::V1;
+    };
 
-    /// Returns the API version supported by the loaded PrismaUI DLL.
-    /// Returns 0 if the function is not exported (i.e., DLL is older than version tracking).
-    [[nodiscard]] inline uint32_t GetAPIVersion() {
-        auto pluginHandle = GetModuleHandle(L"PrismaUI.dll");
-        if (!pluginHandle) {
-            return 0;
-        }
+    template <>
+    struct InterfaceVersionMap<IVPrismaUI2> {
+        static constexpr InterfaceVersion version = InterfaceVersion::V2;
+    };
 
-        auto getVersion =
-            reinterpret_cast<_GetPrismaUIAPIVersion>(GetProcAddress(pluginHandle, "GetPrismaUIAPIVersion"));
-        if (getVersion) {
-            return getVersion();
-        }
-
-        // DLL exists but doesn't export GetPrismaUIAPIVersion — it's version 1
-        return 1;
-    }
+    typedef void* (*RequestPluginAPIFunc)(InterfaceVersion interfaceVersion);
 
     /// Request the PrismaUI API interface.
     /// Recommended: Send your request during or after SKSEMessagingInterface::kMessage_PostLoad to make sure the dll
     /// has already been loaded
-
     [[nodiscard]] inline void* RequestPluginAPI(InterfaceVersion a_interfaceVersion = InterfaceVersion::V1) {
         auto pluginHandle = GetModuleHandle(L"PrismaUI.dll");
         if (!pluginHandle) {
             return nullptr;
         }
 
-        auto requestAPIFunction = reinterpret_cast<_RequestPluginAPI>(GetProcAddress(pluginHandle, "RequestPluginAPI"));
+        auto requestAPIFunction =
+            reinterpret_cast<RequestPluginAPIFunc>(GetProcAddress(pluginHandle, "RequestPluginAPI"));
 
         if (requestAPIFunction) {
             return requestAPIFunction(a_interfaceVersion);
         }
 
         return nullptr;
+    }
+
+    /// Request a specific PrismaUI API interface version.
+    /// Returns nullptr if the loaded PrismaUI DLL does not support the requested version.
+    ///
+    /// Usage:
+    ///   auto* m_prismaUI   = PRISMA_UI_API::RequestPluginAPI<PRISMA_UI_API::IVPrismaUI1>();
+    ///   auto* m_prismaUIv2 = PRISMA_UI_API::RequestPluginAPI<PRISMA_UI_API::IVPrismaUI2>();
+    template <typename T>
+    [[nodiscard]] inline T* RequestPluginAPI() {
+        return static_cast<T*>(RequestPluginAPI(InterfaceVersionMap<T>::version));
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,3 +60,7 @@ RequestPluginAPI(const PRISMA_UI_API::InterfaceVersion a_interfaceVersion) {
 
   return nullptr;
 }
+
+extern "C" DLLEXPORT uint32_t SKSEAPI GetPrismaUIAPIVersion() {
+  return 2;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -52,15 +52,13 @@ RequestPluginAPI(const PRISMA_UI_API::InterfaceVersion a_interfaceVersion) {
 
   switch (a_interfaceVersion) {
   case PRISMA_UI_API::InterfaceVersion::V1:
-    logger::info("RequestPluginAPI returned the API singleton");
-    return static_cast<void *>(api);
+    logger::info("RequestPluginAPI returned V1 interface");
+    return static_cast<PRISMA_UI_API::IVPrismaUI1*>(api);
+  case PRISMA_UI_API::InterfaceVersion::V2:
+    logger::info("RequestPluginAPI returned V2 interface");
+    return static_cast<PRISMA_UI_API::IVPrismaUI2*>(api);
+  default:
+    logger::info("RequestPluginAPI requested unsupported interface version");
+    return nullptr;
   }
-
-  logger::info("RequestPluginAPI requested the wrong interface version");
-
-  return nullptr;
-}
-
-extern "C" DLLEXPORT uint32_t SKSEAPI GetPrismaUIAPIVersion() {
-  return 2;
 }


### PR DESCRIPTION
RegisterConsoleCallback() allows a plugin to request JS console logs specific to their View.

The public ABI is version and RegisterConsoleCallback() is only available using `IVPrismaUI2`.

Plugin developer should test if `IVPrismaUI2` is available before using the function in case the end-user has an older version of the PrismaUI DLL.


```C++
PRISMA_UI_API::IVPrismaUI1* m_prismaUI = nullptr;
PRISMA_UI_API::IVPrismaUI2* m_prismaUIv2 = nullptr;
  
m_prismaUI = PRISMA_UI_API::RequestPluginAPI<PRISMA_UI_API::IVPrismaUI1>();
 
if ((m_prismaUIv2 = PRISMA_UI_API::RequestPluginAPI<PRISMA_UI_API::IVPrismaUI2>())) {
    m_prismaUIv2->RegisterConsoleCallback(m_view, OnConsoleMessage);
    logger::info("UIManager: Console callback registered");
} else {
    logger::warn("UIManager: PrismaUI v2 API not available - console callback not registered");
    }
    
void OnConsoleMessage(PrismaView view, PRISMA_UI_API::ConsoleMessageLevel level, const char* message)
{
    switch (level) {
        case PRISMA_UI_API::ConsoleMessageLevel::Error:
            logger::error("[JS]: {}", message);
            break;
        case PRISMA_UI_API::ConsoleMessageLevel::Warning:
            logger::warn("[JS]: {}", message);
            break;
        case PRISMA_UI_API::ConsoleMessageLevel::Debug:
            logger::debug("[JS] View {}: {}", view, message);
            break;
        default:
            logger::info("[JS] View {}: {}", view, message);
            break;
    }
}
```

In game testing:

Nexus PrismaUI
Several Nexus Prisma Mods.
Custom mod with and without new header and no change code
Custom mod with updated both new API's

Updated PrismaUI
Several Nexus Prisma Mods.
Custom mod with and without new header and no change code
Custom mod with updated both new API's

---

# Console Callback API

PrismaUI exposes a mechanism for consumer plugins to receive JavaScript console messages (`console.log`, `console.warn`, `console.error`, etc.) from their views.

## Requesting the V2 Interface

`RegisterConsoleCallback` is part of the `IVPrismaUI2` interface. Use the template `RequestPluginAPI` to request it:

```cpp
auto* v2 = PRISMA_UI_API::RequestPluginAPI<PRISMA_UI_API::IVPrismaUI2>();
if (v2) {
    // V2 interface is available
}
```

If the loaded PrismaUI DLL does not support `IVPrismaUI2`, the call returns `nullptr`. This allows your plugin to gracefully degrade when users have an older PrismaUI version installed.

### Interface version history

| Interface | Added |
|-----------|-------|
| `IVPrismaUI1` | Original API (`CreateView` through `HasAnyActiveFocus`) |
| `IVPrismaUI2` | `RegisterConsoleCallback` |

## RegisterConsoleCallback

Register a callback to receive JavaScript console messages from a specific view.

```cpp
virtual void RegisterConsoleCallback(PrismaView view, ConsoleMessageCallback callback) noexcept = 0;
```

### Parameters

- **view** — The view to listen to. Messages from other views/plugins are not received.
- **callback** — Function pointer to receive messages, or `nullptr` to unregister.

### Callback signature

```cpp
typedef void (*ConsoleMessageCallback)(PrismaView view, ConsoleMessageLevel level, const char* message);
```

### ConsoleMessageLevel enum

```cpp
enum class ConsoleMessageLevel : uint8_t {
    Log = 0,    // console.log()
    Warning,    // console.warn()
    Error,      // console.error(), uncaught exceptions, CSP violations
    Debug,      // console.debug()
    Info        // console.info()
};
```

### Threading

The callback is dispatched on the **game thread** via `SKSE::GetTaskInterface()->AddTask()`, consistent with other PrismaUI callbacks like `RegisterJSListener` and `OnDomReadyCallback`. It is safe to call SKSE/RE functions from within the callback.

### Scope

Each view has its own isolated JavaScript context. Registering a console callback on your view only receives messages from **your** view. Other plugins using PrismaUI are not affected and their messages are not visible to your callback.

### What it catches

Because this hooks into Ultralight's native `OnAddConsoleMessage` listener, it captures more than just `console.log()` calls:

- `console.log()`, `console.warn()`, `console.error()`, `console.info()`, `console.debug()`
- Uncaught JavaScript exceptions
- `console.assert()` failures
- CSP (Content Security Policy) violations
- CSS/rendering warnings
- Network errors from the view

## Full Example

```cpp
#include "PrismaUI_API.h"

PRISMA_UI_API::IVPrismaUI1* g_prismaUI = nullptr;
PRISMA_UI_API::IVPrismaUI2* g_prismaUIv2 = nullptr;
PrismaView g_view = 0;

// Console message handler
void OnConsoleMessage(PrismaView view, PRISMA_UI_API::ConsoleMessageLevel level, const char* message) {
    switch (level) {
        case PRISMA_UI_API::ConsoleMessageLevel::Error:
            logger::error("[JS Error] View {}: {}", view, message);
            break;
        case PRISMA_UI_API::ConsoleMessageLevel::Warning:
            logger::warn("[JS Warn] View {}: {}", view, message);
            break;
        default:
            logger::info("[JS] View {}: {}", view, message);
            break;
    }
}

void OnDomReady(PrismaView view) {
    // Register console callback if V2 interface is available
    if (g_prismaUIv2) {
        g_prismaUIv2->RegisterConsoleCallback(view, OnConsoleMessage);
        logger::info("Console callback registered for view {}", view);
    }
}

void SetupUI() {
    g_prismaUI = PRISMA_UI_API::RequestPluginAPI<PRISMA_UI_API::IVPrismaUI1>();
    g_prismaUIv2 = PRISMA_UI_API::RequestPluginAPI<PRISMA_UI_API::IVPrismaUI2>();

    if (g_prismaUI) {
        g_view = g_prismaUI->CreateView("my_plugin/index.html", OnDomReady);
    }
}

// To unregister later:
void Cleanup() {
    if (g_prismaUIv2 && g_view) {
        g_prismaUIv2->RegisterConsoleCallback(g_view, nullptr);
    }
}
```

## Minimal Example (without version guard)

If your plugin requires the latest PrismaUI and doesn't need to support older versions:

```cpp
void OnConsoleMessage(PrismaView view, PRISMA_UI_API::ConsoleMessageLevel level, const char* message) {
    logger::info("[JS] {}", message);
}

// In OnDomReady:
g_prismaUIv2->RegisterConsoleCallback(view, OnConsoleMessage);
```
