### PR TITLE
fixed input handler not passing keyboard events to web ui

### DIFF
--- a/src/PrismaUI/Core.cpp
+++ b/src/PrismaUI/Core.cpp
@@ -193,15 +193,13 @@ namespace PrismaUI::Core {
             if (input_handler_initialized.compare_exchange_strong(expected_ih_init, true)) {
                 Initialize(hWnd, &ultralightThread, &views, &viewsMutex);
 
-                // Schedule WndProc hook installation on the main thread (required for
-                // SetWindowSubclass)
-                SKSE::GetTaskInterface()->AddTask([]() {
-                    if (InstallWndProcHook()) {
-                        logger::info("WndProc hook installed successfully.");
-                    } else {
-                        logger::error("Failed to install WndProc hook!");
-                    }
-                });
+                // Install WndProc subclass directly here — SetWindowSubclass requires
+                // being called from the thread that owns the HWND (this render thread).
+                if (InstallWndProcHook()) {
+                    logger::info("WndProc hook installed successfully.");
+                } else {
+                    logger::error("Failed to install WndProc hook!");
+                }
             }
         } else if (!hWnd) {
             logger::warn("InitGraphics: Could not obtain HWND.");


### PR DESCRIPTION
SetWindowSubclass was being scheduled via SKSE::GetTaskInterface()->AddTask() under the assumption that it needed to run on the "main game thread". In reality, SetWindowSubclass (comctl32) requires being called from the same thread that owns the window's message queue — i.e. the thread that called CreateWindow.

Skyrim's render window is owned by the D3D present/render thread (thread 56216 in our case). The SKSE task interface runs on a different thread (49604), so SetWindowSubclass would always return FALSE with GetLastError() == 0 — no useful error, just a silent failure.

Fix: removed the AddTask wrapper and call InstallWndProcHook() directly inside InitGraphics(), which already executes on the D3DPresent hook — the same thread that owns the HWND. Thread matches, subclass installs successfully.

Diagnosed by logging GetWindowThreadProcessId vs GetCurrentThreadId at the call site, which immediately showed the thread mismatch.