### PR TITLE
expose ime state event

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ target_link_libraries(${PROJECT_NAME}
     UltralightCore
     WebCore
     comctl32  # Required for SetWindowSubclass/RemoveWindowSubclass
+    imm32     # Required for IME (Input Method Editor) support
 )
 
 # Delay-load Ultralight DLLs so they can be loaded from custom path at runtime

--- a/IME_SUPPORT.md
+++ b/IME_SUPPORT.md
@@ -1,0 +1,78 @@
+# IME Setup For PrismaUI
+
+PrismaUI exposes an IME state event to allow custom display of IME composition and candidate windows for non-English text input.
+
+## The Setup Flow
+
+1. listen for PrismaUI's IME event in the page
+2. render a composition and candidate overlay from that state
+3. disable app shortcuts while IME is active
+4. pass the same IME state to both the input and overlay
+
+## Step 1: Receive IME State
+
+PrismaUI dispatches a `prismaIME_state` custom event into the page. Attach your listener on `window` (or `document`):
+
+```js
+window.addEventListener('prismaIME_state', (e) => {
+  const state = e.detail || {};
+  // store state in your app (e.detail is the payload)
+});
+```
+
+The **payload is in `event.detail`** - use it as the full IME state object.
+
+The event should be treated as a full snapshot, not a delta. Expect it to update whenever the visible IME state changes while the text field is active, including:
+
+- composition start
+- composition text changes
+- candidate list open/change/close
+- composition commit/end
+- focus loss or other clear/reset cases
+
+The payload shape your app should expect is:
+
+```json
+{
+  "active": true,
+  "composition": "とうきょう",
+  "caret": 5,
+  "candidates": ["とうきょう", "東京", "トウキョウ", "東京都"],
+  "selectedIndex": 2
+}
+```
+
+Field meanings:
+
+- `active`: whether PrismaUI currently considers IME composition active
+- `composition`: the current uncommitted composition string
+- `caret`: zero-based caret position inside `composition`; use it to split the composition string and draw an inline caret
+- `candidates`: the currently visible candidate page
+- `selectedIndex`: zero-based index of the highlighted candidate within `candidates`; use `-1` when there is no valid selection
+
+## Step 2: Render A Custom Overlay
+
+Render the composition text, caret, and candidate list from the IME state. The overlay is **display-only**: PrismaUI owns IME logic (arrow keys, number keys, commit).
+
+Place the overlay near the input (e.g. directly below it). Keep it simple:
+
+- hide it when IME is inactive (or when there is no composition and no candidates; showing when `composition` or `candidates` exist even if `active` is false can avoid flicker)
+- split the composition string at the caret
+- draw candidates with a selected style based on `selectedIndex`
+
+## Step 3: Disable App Shortcuts While IME Is Active
+
+While the user is composing text, your app-level keyboard handlers should get out of the way.
+
+This is separate from PrismaUI's internal IME handling. PrismaUI owns the native IME integration; your web app still needs to stop its own shortcuts from reacting while IME is active. Your text input may handle `Tab`, arrow keys, `Enter`, `Escape`, and other shortcuts; the app may also have global key handlers (e.g. Escape to close). All of those should be treated as IME-owned while composing.
+
+If you do not gate those keys, the app can submit, close the UI, or move selection while the user is still converting text.
+
+## Step 4: Wire It In The App
+
+Your app shell should pass IME state into both places that need it:
+
+- the text input, so it can suspend shortcut handling
+- the overlay, so it can render composition UI
+
+When the UI (or input) is closed and reopened, clear or re-initialize IME state (e.g. set to inactive, empty composition, no candidates). Otherwise the overlay can show stale composition or candidates from the previous session.

--- a/src/PrismaUI/ImeHelper.cpp
+++ b/src/PrismaUI/ImeHelper.cpp
@@ -1,0 +1,386 @@
+#include "ImeHelper.h"
+
+#include <cstdio>
+#include <imm.h>
+#pragma comment(lib, "imm32.lib")
+
+#include "Communication.h"
+#include "Core.h"
+#include "ViewManager.h"
+
+#include <SKSE/SKSE.h>
+
+namespace PrismaUI {
+
+namespace {
+
+struct ImeCandidateState {
+    std::vector<std::string> candidates;
+    int selectedIndex = -1;
+};
+
+struct ImeUiState {
+    bool active = false;
+    std::string composition;
+    int caret = 0;
+    ImeCandidateState candidateState;
+};
+
+std::string EscapeForJson(const std::string& s) {
+    std::string r;
+    r.reserve(s.size() + 8);
+    for (unsigned char c : s) {
+        if (c == '"')
+            r += "\\\"";
+        else if (c == '\\')
+            r += "\\\\";
+        else if (c == '\n')
+            r += "\\n";
+        else if (c == '\r')
+            r += "\\r";
+        else if (c == '\t')
+            r += "\\t";
+        else if (c < 32) {
+            char hex[8];
+            snprintf(hex, sizeof(hex), "\\u%04x", c);
+            r += hex;
+        } else
+            r += c;
+    }
+    return r;
+}
+
+}  // namespace
+
+const char* ImeHelper::MessageName(UINT uMsg) {
+    switch (uMsg) {
+        case WM_GETDLGCODE: return "WM_GETDLGCODE";
+        case WM_INPUTLANGCHANGE: return "WM_INPUTLANGCHANGE";
+        case WM_IME_SETCONTEXT: return "WM_IME_SETCONTEXT";
+        case WM_IME_STARTCOMPOSITION: return "WM_IME_STARTCOMPOSITION";
+        case WM_IME_COMPOSITION: return "WM_IME_COMPOSITION";
+        case WM_IME_ENDCOMPOSITION: return "WM_IME_ENDCOMPOSITION";
+        case WM_IME_CHAR: return "WM_IME_CHAR";
+        case WM_IME_NOTIFY: return "WM_IME_NOTIFY";
+        default: return "WM_IME_?";
+    }
+}
+
+void ImeHelper::SetCallbacks(ImeEscapeForJSCallback escapeForJS,
+                             ImeQueueCommittedCharCallback queueCommittedChar,
+                             ImeConvertUtf16ToUtf8Callback convertUtf16ToUtf8) {
+    m_escapeForJS = std::move(escapeForJS);
+    m_queueCommittedChar = std::move(queueCommittedChar);
+    m_convertUtf16ToUtf8 = std::move(convertUtf16ToUtf8);
+}
+
+void ImeHelper::SetContext(const ImeHelperContext& ctx) { m_ctx = ctx; }
+
+void ImeHelper::SetExecutor(SingleThreadExecutor* executor) { m_executor = executor; }
+
+void ImeHelper::Initialize(HWND hwnd) {
+    if (!hwnd) return;
+
+    // Use system's IME context to preserve conversion mode across focus cycles.
+    // ImmCreateContext yields a fresh context that loses Japanese IME state (a->あ, etc.) on re-associate.
+    m_context = ImmGetContext(hwnd);
+    if (m_context) {
+        m_contextOwned = false;
+    } else {
+        m_context = ImmCreateContext();
+        m_contextOwned = true;
+        if (!m_context) {
+            logger::warn("IME: Failed to create IME context");
+        }
+    }
+}
+
+void ImeHelper::Shutdown(HWND hwnd) {
+    if (!m_context) return;
+
+    m_lastKnownTextInputFocus = false;
+    m_associated = false;
+    if (hwnd) {
+        ImmAssociateContext(hwnd, nullptr);
+    }
+    if (m_contextOwned) {
+        ImmDestroyContext(m_context);
+    } else if (hwnd) {
+        ImmReleaseContext(hwnd, m_context);
+    }
+    m_context = nullptr;
+}
+
+void ImeHelper::SetAssociation(bool enabled) {
+    if (!m_context || !m_ctx.hwnd) return;
+
+    const bool previous = m_associated.exchange(enabled);
+    if (previous == enabled) return;
+
+    // ImmAssociateContext must run on the thread that owns the window (main thread).
+    HWND hwnd = m_ctx.hwnd;
+
+    HIMC himc = enabled ? m_context : nullptr;
+    SKSE::GetTaskInterface()->AddTask([hwnd, himc]() { ImmAssociateContext(hwnd, himc); });
+}
+
+void ImeHelper::ModifySetContextLParam(LPARAM* lParam, UINT uMsg) {
+    if (uMsg == WM_IME_SETCONTEXT && lParam) {
+        // Suppress Windows fallback IME UI in fullscreen (candidate/composition windows).
+        // Skyrim runs fullscreen; native IME windows would overlay the game.
+        *lParam = 0;
+    }
+}
+
+void ImeHelper::ClearStateInJS(Core::PrismaViewId viewId) {
+    SendStateToJS(viewId, nullptr, false);
+}
+
+void ImeHelper::SendStateToJS(Core::PrismaViewId viewId, HWND hwnd, bool active) {
+    if (!viewId) return;
+    if (!m_escapeForJS || !m_convertUtf16ToUtf8) return;
+
+    ImeUiState state;
+    state.active = active;
+
+    if (hwnd) {
+        HIMC himc = ImmGetContext(hwnd);
+        if (himc) {
+            // Read composition string
+            const LONG compSize = ImmGetCompositionString(himc, GCS_COMPSTR, nullptr, 0);
+            if (compSize > 0) {
+                std::vector<wchar_t> buffer((compSize / static_cast<LONG>(sizeof(wchar_t))) + 1, L'\0');
+                const LONG copied = ImmGetCompositionString(himc, GCS_COMPSTR, buffer.data(), compSize);
+                if (copied > 0) {
+                    std::wstring wideComp(buffer.data(), copied / static_cast<LONG>(sizeof(wchar_t)));
+                    state.composition = m_convertUtf16ToUtf8(wideComp.data(), static_cast<int>(wideComp.size()));
+                }
+            }
+
+            // Read caret position
+            const LONG cursorPos = ImmGetCompositionString(himc, GCS_CURSORPOS, nullptr, 0);
+            if (cursorPos >= 0) {
+                state.caret = static_cast<int>(cursorPos);
+            }
+
+            // Read candidate list
+            const DWORD bytesNeeded = ImmGetCandidateList(himc, 0, nullptr, 0);
+            if (bytesNeeded > 0) {
+                std::vector<char> buffer(bytesNeeded);
+                const DWORD bytesCopied =
+                    ImmGetCandidateList(himc, 0, reinterpret_cast<LPCANDIDATELIST>(buffer.data()), bytesNeeded);
+                if (bytesCopied >= sizeof(CANDIDATELIST)) {
+                    auto* candidateList = reinterpret_cast<LPCANDIDATELIST>(buffer.data());
+                    const DWORD candidateCount = candidateList->dwCount;
+                    if (candidateCount > 0) {
+                        const DWORD pageStart =
+                            candidateList->dwPageStart < candidateCount ? candidateList->dwPageStart : 0;
+                        const DWORD pageSize =
+                            candidateList->dwPageSize == 0 ? candidateCount : candidateList->dwPageSize;
+                        const DWORD pageEnd =
+                            (pageStart + pageSize) < candidateCount ? (pageStart + pageSize) : candidateCount;
+
+                        for (DWORD index = pageStart; index < pageEnd; ++index) {
+                            if (candidateList->dwOffset[index] >= bytesCopied) continue;
+                            const wchar_t* candidate =
+                                reinterpret_cast<const wchar_t*>(buffer.data() + candidateList->dwOffset[index]);
+                            std::wstring wideCandidate(candidate ? candidate : L"");
+                            std::string utf8Candidate =
+                                wideCandidate.empty() ? ""
+                                                    : m_convertUtf16ToUtf8(wideCandidate.data(),
+                                                                           static_cast<int>(wideCandidate.size()));
+                            state.candidateState.candidates.push_back(std::move(utf8Candidate));
+                        }
+
+                        if (candidateList->dwSelection >= pageStart && candidateList->dwSelection < pageEnd) {
+                            state.candidateState.selectedIndex =
+                                static_cast<int>(candidateList->dwSelection - pageStart);
+                        }
+
+                        // Override with recommended conversion for Japanese IME (とうきょう -> 東京)
+                        if (state.candidateState.candidates.size() > 0 && !state.composition.empty()) {
+                            const HKL hkl =
+                                GetKeyboardLayout(GetWindowThreadProcessId(hwnd, nullptr));
+                            if (hkl) {
+                                std::wstring wideComp;
+                                const LONG cs = ImmGetCompositionString(himc, GCS_COMPSTR, nullptr, 0);
+                                if (cs > 0) {
+                                    std::vector<wchar_t> compBuf((cs / sizeof(wchar_t)) + 1, L'\0');
+                                    ImmGetCompositionString(himc, GCS_COMPSTR, compBuf.data(), cs);
+                                    wideComp.assign(compBuf.data(), cs / sizeof(wchar_t));
+                                }
+                                if (!wideComp.empty()) {
+                                    const DWORD bufSize =
+                                        ImmGetConversionListW(hkl, himc, wideComp.c_str(), nullptr, 0, GCL_CONVERSION);
+                                    if (bufSize >= sizeof(CANDIDATELIST)) {
+                                        std::vector<char> convBuf(bufSize);
+                                        if (ImmGetConversionListW(hkl, himc, wideComp.c_str(),
+                                                                 reinterpret_cast<LPCANDIDATELIST>(convBuf.data()),
+                                                                 bufSize, GCL_CONVERSION) != 0) {
+                                            auto* convList = reinterpret_cast<LPCANDIDATELIST>(convBuf.data());
+                                            if (convList->dwCount > 0 &&
+                                                !(convList->dwStyle == IME_CAND_CODE && convList->dwCount == 1)) {
+                                                const DWORD offset0 = convList->dwOffset[0];
+                                                if (offset0 < bufSize) {
+                                                    const wchar_t* str =
+                                                        reinterpret_cast<const wchar_t*>(convBuf.data() + offset0);
+                                                    if (str) {
+                                                        std::wstring recommended(str);
+                                                        std::string recommendedUtf8 =
+                                                            m_convertUtf16ToUtf8(recommended.data(),
+                                                                               static_cast<int>(recommended.size()));
+                                                        for (size_t i = 0; i < state.candidateState.candidates.size();
+                                                             ++i) {
+                                                            if (state.candidateState.candidates[i] == recommendedUtf8) {
+                                                                state.candidateState.selectedIndex =
+                                                                    static_cast<int>(i);
+                                                                break;
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            ImmReleaseContext(hwnd, himc);
+        } else if (!active) {
+            // No context, clear state
+        }
+    }
+
+    // Build and dispatch JSON
+    std::string json = "{";
+    json += "\"active\":";
+    json += state.active ? "true" : "false";
+    json += ",\"composition\":\"";
+    json += EscapeForJson(state.composition);
+    json += "\",\"caret\":";
+    json += std::to_string(state.caret);
+    json += ",\"selectedIndex\":";
+    json += std::to_string(state.candidateState.selectedIndex);
+    json += ",\"candidates\":[";
+    for (size_t i = 0; i < state.candidateState.candidates.size(); ++i) {
+        if (i > 0) json += ",";
+        json += "\"";
+        json += EscapeForJson(state.candidateState.candidates[i]);
+        json += "\"";
+    }
+    json += "]}";
+
+    const std::string escapedJson = m_escapeForJS(json);
+    if (escapedJson.empty()) return;
+
+    const std::string script =
+        "window.dispatchEvent(new CustomEvent('prismaIME_state',{detail:JSON.parse('" + escapedJson + "')}))";
+    Communication::Invoke(viewId, script.c_str());
+}
+
+bool ImeHelper::HandleMessage(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam,
+                              Core::PrismaViewId focusedViewId, bool* outHandled) {
+    if (!outHandled || focusedViewId == 0) return false;
+
+    if (!m_associated.load()) return false;
+
+    switch (uMsg) {
+        case WM_IME_STARTCOMPOSITION:
+            *outHandled = true;
+            SendStateToJS(focusedViewId, hwnd, true);
+            return true;
+        case WM_IME_ENDCOMPOSITION:
+            *outHandled = true;
+            ClearStateInJS(focusedViewId);
+            return true;
+        case WM_IME_CHAR:
+            *outHandled = true;
+            return true;
+        case WM_IME_COMPOSITION: {
+            *outHandled = true;
+            if (m_queueCommittedChar) {
+                HIMC himc = ImmGetContext(hwnd);
+                if (himc) {
+                    if (lParam & GCS_RESULTSTR) {
+                        const int size = ImmGetCompositionString(himc, GCS_RESULTSTR, nullptr, 0);
+                        if (size > 0) {
+                            std::vector<wchar_t> buf((size / sizeof(wchar_t)) + 1, L'\0');
+                            ImmGetCompositionString(himc, GCS_RESULTSTR, buf.data(),
+                                                   static_cast<DWORD>(buf.size() * sizeof(wchar_t)));
+                            m_queueCommittedChar(std::wstring(buf.data()), lParam);
+                        }
+                    }
+                    ImmReleaseContext(hwnd, himc);
+                }
+            }
+            SendStateToJS(focusedViewId, hwnd, true);
+            return true;
+        }
+        case WM_IME_NOTIFY:
+            if (wParam == IMN_CHANGECANDIDATE || wParam == IMN_OPENCANDIDATE || wParam == IMN_CLOSECANDIDATE) {
+                *outHandled = true;
+                SendStateToJS(focusedViewId, hwnd, true);
+            }
+            return *outHandled;
+        default:
+            return false;
+    }
+}
+
+void ImeHelper::UpdateStateImpl(Core::PrismaViewId viewId) {
+    if (!m_ctx.viewsMap || !m_ctx.viewsMapMutex || viewId == 0) {
+        m_lastKnownTextInputFocus = false;
+        SetAssociation(false);
+        return;
+    }
+
+    bool stillFocused = false;
+    if (m_ctx.focusedViewIdMutex && m_ctx.currentlyFocusedViewId && m_ctx.isAnyInputCaptureActive) {
+        std::lock_guard lock(*m_ctx.focusedViewIdMutex);
+        stillFocused =
+            m_ctx.isAnyInputCaptureActive->load() && *m_ctx.currentlyFocusedViewId == viewId;
+    }
+
+    if (!stillFocused) {
+        m_lastKnownTextInputFocus = false;
+        ClearStateInJS(viewId);
+        SetAssociation(false);
+        return;
+    }
+
+    std::shared_ptr<Core::PrismaView> targetViewData = nullptr;
+    {
+        std::shared_lock lock(*m_ctx.viewsMapMutex);
+        auto it = m_ctx.viewsMap->find(viewId);
+        if (it != m_ctx.viewsMap->end()) {
+            targetViewData = it->second;
+        }
+    }
+
+    const bool textInputFocused =
+        targetViewData && targetViewData->ultralightView && targetViewData->ultralightView->HasInputFocus();
+    m_lastKnownTextInputFocus = textInputFocused;
+
+    if (!textInputFocused) {
+        ClearStateInJS(viewId);
+    }
+    SetAssociation(textInputFocused);
+}
+
+void ImeHelper::UpdateStateForFocusedView(Core::PrismaViewId viewId) {
+    if (!m_executor) return;
+
+    if (m_executor->IsWorkerThread()) {
+        UpdateStateImpl(viewId);
+        return;
+    }
+
+    m_executor->submit_with_priority(
+        SingleThreadExecutor::Priority::HIGH,
+        [this, viewId]() { UpdateStateImpl(viewId); });
+}
+
+}  // namespace PrismaUI

--- a/src/PrismaUI/ImeHelper.h
+++ b/src/PrismaUI/ImeHelper.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include "Core.h"
+
+#include <atomic>
+#include <functional>
+#include <map>
+#include <memory>
+#include <shared_mutex>
+#include <string>
+
+class SingleThreadExecutor;
+
+namespace PrismaUI {
+
+// Callbacks ImeHelper needs from InputHandler (avoids circular dependency)
+using ImeEscapeForJSCallback = std::function<std::string(const std::string&)>;
+using ImeQueueCommittedCharCallback = std::function<void(const std::wstring&, LPARAM)>;
+using ImeConvertUtf16ToUtf8Callback = std::function<std::string(const wchar_t*, int)>;
+
+// Context references for focus/IME state checks
+struct ImeHelperContext {
+    HWND hwnd = nullptr;
+    std::map<Core::PrismaViewId, std::shared_ptr<Core::PrismaView>>* viewsMap = nullptr;
+    std::shared_mutex* viewsMapMutex = nullptr;
+    std::mutex* focusedViewIdMutex = nullptr;
+    Core::PrismaViewId* currentlyFocusedViewId = nullptr;
+    std::atomic<bool>* isAnyInputCaptureActive = nullptr;
+};
+
+// Custom IME composition support: reads Windows IME state and dispatches to JS
+// for custom candidate/composition UI (hides native IME windows in fullscreen).
+class ImeHelper {
+public:
+    ImeHelper() = default;
+    ~ImeHelper() = default;
+
+    // Initialize IME context. Must be called on main thread with valid hwnd.
+    void Initialize(HWND hwnd);
+
+    // Release IME context and disassociate from window. Call before hwnd becomes invalid.
+    void Shutdown(HWND hwnd);
+
+    // Set callbacks and context. Call after Initialize, before any other operations.
+    void SetCallbacks(ImeEscapeForJSCallback escapeForJS, ImeQueueCommittedCharCallback queueCommittedChar,
+                      ImeConvertUtf16ToUtf8Callback convertUtf16ToUtf8);
+    void SetContext(const ImeHelperContext& ctx);
+    void SetExecutor(SingleThreadExecutor* executor);
+
+    // Associate/unassociate IME context with window. Must run on main thread for ImmAssociateContext.
+    void SetAssociation(bool enabled);
+
+    // Update IME state based on focused view and text input focus. Call from ultralight thread
+    // or via executor.
+    void UpdateStateForFocusedView(Core::PrismaViewId viewId);
+
+    // Send current IME composition/candidate state to JS, or clear it.
+    void SendStateToJS(Core::PrismaViewId viewId, HWND hwnd, bool active);
+    void ClearStateInJS(Core::PrismaViewId viewId);
+
+    // Returns true if IME is currently associated with the window.
+    bool IsAssociated() const { return m_associated.load(); }
+
+    // Handle WM_IME_* in SubclassProc. Returns true if message was consumed (handled).
+    bool HandleMessage(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam,
+                       Core::PrismaViewId focusedViewId, bool* outHandled);
+
+    // Modify lParam for WM_IME_SETCONTEXT (suppress native IME UI). Call before DefSubclassProc.
+    void ModifySetContextLParam(LPARAM* lParam, UINT uMsg);
+
+    // Returns human-readable name for IME message type.
+    static const char* MessageName(UINT uMsg);
+
+private:
+    void UpdateStateImpl(Core::PrismaViewId viewId);
+
+    HIMC m_context = nullptr;
+    bool m_contextOwned = false;
+    std::atomic<bool> m_associated{false};
+    std::atomic<bool> m_lastKnownTextInputFocus{false};
+
+    ImeEscapeForJSCallback m_escapeForJS;
+    ImeQueueCommittedCharCallback m_queueCommittedChar;
+    ImeConvertUtf16ToUtf8Callback m_convertUtf16ToUtf8;
+    ImeHelperContext m_ctx;
+    SingleThreadExecutor* m_executor = nullptr;
+};
+
+}  // namespace PrismaUI

--- a/src/PrismaUI/InputHandler.cpp
+++ b/src/PrismaUI/InputHandler.cpp
@@ -4,6 +4,7 @@
 
 #include "Communication.h"
 #include "Core.h"
+#include "ImeHelper.h"
 #include "Utils/Encoding.h"
 #include "ViewManager.h"
 #pragma comment(lib, "comctl32.lib")
@@ -37,6 +38,8 @@ namespace PrismaUI::InputHandler {
     static std::atomic<bool> g_wndProcInstalled = false;
     static constexpr UINT_PTR SUBCLASS_ID = 0x505249534D41;  // "PRISMA" in hex
     static std::mutex g_wndProcMutex;                        // Thread-safe installation
+
+    static ImeHelper g_imeHelper;
 
     // Clipboard helper functions
     std::string EscapeForJS(const std::string& text) {
@@ -432,6 +435,12 @@ namespace PrismaUI::InputHandler {
 
     LRESULT CALLBACK SubclassProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam, UINT_PTR uIdSubclass,
                                   DWORD_PTR /*dwRefData*/) {
+        if (uMsg == WM_IME_SETCONTEXT) {
+            LPARAM imeLParam = lParam;
+            g_imeHelper.ModifySetContextLParam(&imeLParam, uMsg);
+            lParam = imeLParam;
+        }
+
         if (g_isAnyInputCaptureActive.load()) {
             bool handledByUI = false;
             Core::PrismaViewId focusedViewIdCopy;
@@ -441,6 +450,12 @@ namespace PrismaUI::InputHandler {
             }
 
             if (focusedViewIdCopy != 0) {
+                if (g_imeHelper.HandleMessage(hwnd, uMsg, wParam, lParam, focusedViewIdCopy, &handledByUI)) {
+                    if (handledByUI) {
+                        return 0;
+                    }
+                }
+
                 switch (uMsg) {
                     case WM_KEYDOWN: {
                         // Handle Ctrl+V (Paste)
@@ -627,6 +642,15 @@ namespace PrismaUI::InputHandler {
 
         logger::info("PrismaUI::InputHandler Initialized with HWND: {}", (void*)g_hWnd);
 
+        g_imeHelper.SetCallbacks(
+            [](const std::string& s) { return EscapeForJS(s); },
+            [](const std::wstring& ws, LPARAM lp) { QueueCommittedCharEvent(ws, lp); },
+            [](const wchar_t* p, int len) { return ConvertUtf16ToUtf8(p, len); });
+        g_imeHelper.SetContext({g_hWnd, g_viewsMap, g_viewsMapMutex, &g_focusedViewIdMutex,
+                                &g_currentlyFocusedViewId, &g_isAnyInputCaptureActive});
+        g_imeHelper.SetExecutor(g_ultralightThreadExecutor);
+        g_imeHelper.Initialize(g_hWnd);
+
         auto inputEventSource = RE::BSInputDeviceManager::GetSingleton();
         if (inputEventSource) {
             inputEventSource->AddEventSink(MouseEventListener::GetSingleton());
@@ -703,6 +727,8 @@ namespace PrismaUI::InputHandler {
             logger::debug("PrismaUI Input Capture System Enabled for View [{}].", viewId);
         }
 
+        g_imeHelper.UpdateStateForFocusedView(viewId);
+
         g_mouseButtonStates[0] = g_mouseButtonStates[1] = g_mouseButtonStates[2] = false;
     }
 
@@ -722,6 +748,10 @@ namespace PrismaUI::InputHandler {
 
         if (disableSystem) {
             if (g_isAnyInputCaptureActive.exchange(false)) {
+                if (currentFocusedBeforeDisable != 0) {
+                    g_imeHelper.ClearStateInJS(currentFocusedBeforeDisable);
+                }
+                g_imeHelper.SetAssociation(false);
                 logger::debug("PrismaUI Input Capture System Disabled (was active for View [{}]).",
                               currentFocusedBeforeDisable);
 
@@ -795,6 +825,8 @@ namespace PrismaUI::InputHandler {
         }
 
         g_ultralightThreadExecutor->submit([viewId_copy = focusedViewIdCopy, ev_queue = std::move(eventsToProcess)]() {
+            g_imeHelper.UpdateStateForFocusedView(viewId_copy);
+
             std::shared_ptr<Core::PrismaView> targetViewData = nullptr;
             {
                 std::shared_lock lock(*g_viewsMapMutex);
@@ -896,6 +928,8 @@ namespace PrismaUI::InputHandler {
         }
 
         UninstallWndProcHook();
+
+        g_imeHelper.Shutdown(g_hWnd);
 
         g_hWnd = nullptr;
         g_ultralightThreadExecutor = nullptr;


### PR DESCRIPTION
## Summary

This PR takes over IME (Input Method Editor) handling from the system default and exposes an IME state event so web UIs can render custom composition and candidate selection overlays. This is needed because the native Windows IME panels (candidate lists, composition UI) overlay the game poorly, being unstyled, appearing in the top left corner instead of next to the text input, and being active even when the text input doesn't have focus.

This PR affects IME-dependent languages (in particular Japanese). It should not affect typical English-language players at all.

## Key Changes

### IME takeover

- **`ImeHelper`** – New module that intercepts `WM_IME_*` messages in the subclassed WndProc and handles them before the default handler.
- **Native IME UI suppressed** – `WM_IME_SETCONTEXT` lParam is set to 0 so Windows does not show its own candidate/composition windows.
- **Committed text** – IME-committed text is read from `GCS_RESULTSTR` in `WM_IME_COMPOSITION` and queued via the existing `QueueCommittedChar` path; `WM_IME_CHAR` is consumed to avoid double input.
- **Association** – IME context is associated with the window only when a text input has focus, and disassociated on blur.

### `prismaIME_state` event

- A `prismaIME_state` custom event is dispatched to the page with a JSON payload: `active`, `composition`, `caret`, `candidates`, `selectedIndex`.
- The event is a full snapshot on each change (composition start/update, candidate open/change/close, commit, focus loss).
- Web apps listen on `window` and render their own overlay from this state. See `IME_SUPPORT.md` for integration details.

### Build

- Links `imm32` for IME APIs.

## Files Changed

| File | Change |
|------|--------|
| `src/PrismaUI/ImeHelper.h` | New – IME helper interface |
| `src/PrismaUI/ImeHelper.cpp` | New – IME state reading, event dispatch, message handling |
| `src/PrismaUI/InputHandler.cpp` | Integrates ImeHelper, wires WM_IME handling and focus/association |
| `CMakeLists.txt` | Add `imm32` |
| `IME_SUPPORT.md` | New – integration guide for web UIs |
