### PR TITLE
refactor IME focus handling

### DIFF
--- a/src/PrismaUI/ImeHelper.cpp
+++ b/src/PrismaUI/ImeHelper.cpp
@@ -8,8 +8,6 @@
 #include "Core.h"
 #include "ViewManager.h"
 
-#include <SKSE/SKSE.h>
-
 namespace PrismaUI {
 
 namespace {
@@ -25,6 +23,11 @@ struct ImeUiState {
     int caret = 0;
     ImeCandidateState candidateState;
 };
+
+UINT GetImeAssociationMessageId() {
+    static const UINT kMessageId = RegisterWindowMessageW(L"PrismaUI.ImeAssociation");
+    return kMessageId;
+}
 
 std::string EscapeForJson(const std::string& s) {
     std::string r;
@@ -93,6 +96,46 @@ void ImeHelper::Initialize(HWND hwnd) {
             logger::warn("IME: Failed to create IME context");
         }
     }
+
+    // Start with IME disassociated. The active text input state drives
+    // association via posted window-thread messages.
+    m_associated = false;
+}
+
+bool ImeHelper::IsTextInputFocused() const {
+    return m_ctx.isTextInputFocused && m_ctx.isTextInputFocused->load();
+}
+
+void ImeHelper::DispatchScriptToView(Core::PrismaViewId viewId, const std::string& script) {
+    if (!viewId || script.empty()) {
+        return;
+    }
+
+    if (m_executor && m_executor->IsWorkerThread() && m_ctx.viewsMap && m_ctx.viewsMapMutex) {
+        std::shared_ptr<Core::PrismaView> viewData = nullptr;
+        {
+            std::shared_lock lock(*m_ctx.viewsMapMutex);
+            auto it = m_ctx.viewsMap->find(viewId);
+            if (it != m_ctx.viewsMap->end()) {
+                viewData = it->second;
+            }
+        }
+
+        if (!viewData || !viewData->ultralightView) {
+            return;
+        }
+
+        try {
+            viewData->ultralightView->EvaluateScript(ultralight::String(script.c_str()), nullptr, "");
+        } catch (const std::exception& e) {
+            logger::error("IME: Failed to dispatch state to View [{}]: {}", viewId, e.what());
+        } catch (...) {
+            logger::error("IME: Failed to dispatch state to View [{}]: unknown exception", viewId);
+        }
+        return;
+    }
+
+    Communication::Invoke(viewId, script.c_str());
 }
 
 void ImeHelper::Shutdown(HWND hwnd) {
@@ -114,14 +157,30 @@ void ImeHelper::Shutdown(HWND hwnd) {
 void ImeHelper::SetAssociation(bool enabled) {
     if (!m_context || !m_ctx.hwnd) return;
 
-    const bool previous = m_associated.exchange(enabled);
+    const bool previous = m_associated.load();
     if (previous == enabled) return;
 
-    // ImmAssociateContext must run on the thread that owns the window (main thread).
     HWND hwnd = m_ctx.hwnd;
-
     HIMC himc = enabled ? m_context : nullptr;
-    SKSE::GetTaskInterface()->AddTask([hwnd, himc]() { ImmAssociateContext(hwnd, himc); });
+    if (!PostMessage(hwnd, GetImeAssociationMessageId(), enabled ? 1 : 0, reinterpret_cast<LPARAM>(himc))) {
+        logger::warn("IME: Failed to post association change (enabled={})", enabled);
+        return;
+    }
+
+    m_associated = enabled;
+}
+
+bool ImeHelper::HandleControlMessage(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT* outResult) {
+    if (uMsg != GetImeAssociationMessageId()) {
+        return false;
+    }
+
+    HIMC himc = wParam ? reinterpret_cast<HIMC>(lParam) : nullptr;
+    ImmAssociateContext(hwnd, himc);
+    if (outResult) {
+        *outResult = 0;
+    }
+    return true;
 }
 
 void ImeHelper::ModifySetContextLParam(LPARAM* lParam, UINT uMsg) {
@@ -278,7 +337,7 @@ void ImeHelper::SendStateToJS(Core::PrismaViewId viewId, HWND hwnd, bool active)
 
     const std::string script =
         "window.dispatchEvent(new CustomEvent('prismaIME_state',{detail:JSON.parse('" + escapedJson + "')}))";
-    Communication::Invoke(viewId, script.c_str());
+    DispatchScriptToView(viewId, script);
 }
 
 bool ImeHelper::HandleMessage(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam,
@@ -286,6 +345,7 @@ bool ImeHelper::HandleMessage(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
     if (!outHandled || focusedViewId == 0) return false;
 
     if (!m_associated.load()) return false;
+    if (!IsTextInputFocused()) return false;
 
     switch (uMsg) {
         case WM_IME_STARTCOMPOSITION:
@@ -333,7 +393,6 @@ bool ImeHelper::HandleMessage(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 void ImeHelper::UpdateStateImpl(Core::PrismaViewId viewId) {
     if (!m_ctx.viewsMap || !m_ctx.viewsMapMutex || viewId == 0) {
         m_lastKnownTextInputFocus = false;
-        SetAssociation(false);
         return;
     }
 
@@ -347,27 +406,15 @@ void ImeHelper::UpdateStateImpl(Core::PrismaViewId viewId) {
     if (!stillFocused) {
         m_lastKnownTextInputFocus = false;
         ClearStateInJS(viewId);
-        SetAssociation(false);
         return;
     }
 
-    std::shared_ptr<Core::PrismaView> targetViewData = nullptr;
-    {
-        std::shared_lock lock(*m_ctx.viewsMapMutex);
-        auto it = m_ctx.viewsMap->find(viewId);
-        if (it != m_ctx.viewsMap->end()) {
-            targetViewData = it->second;
-        }
-    }
-
-    const bool textInputFocused =
-        targetViewData && targetViewData->ultralightView && targetViewData->ultralightView->HasInputFocus();
+    const bool textInputFocused = IsTextInputFocused();
     m_lastKnownTextInputFocus = textInputFocused;
 
     if (!textInputFocused) {
         ClearStateInJS(viewId);
     }
-    SetAssociation(textInputFocused);
 }
 
 void ImeHelper::UpdateStateForFocusedView(Core::PrismaViewId viewId) {

--- a/src/PrismaUI/ImeHelper.h
+++ b/src/PrismaUI/ImeHelper.h
@@ -26,6 +26,7 @@ struct ImeHelperContext {
     std::mutex* focusedViewIdMutex = nullptr;
     Core::PrismaViewId* currentlyFocusedViewId = nullptr;
     std::atomic<bool>* isAnyInputCaptureActive = nullptr;
+    std::atomic<bool>* isTextInputFocused = nullptr;
 };
 
 // Custom IME composition support: reads Windows IME state and dispatches to JS
@@ -65,6 +66,9 @@ public:
     bool HandleMessage(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam,
                        Core::PrismaViewId focusedViewId, bool* outHandled);
 
+    // Handle internal control messages that must run on the window thread.
+    bool HandleControlMessage(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT* outResult);
+
     // Modify lParam for WM_IME_SETCONTEXT (suppress native IME UI). Call before DefSubclassProc.
     void ModifySetContextLParam(LPARAM* lParam, UINT uMsg);
 
@@ -72,6 +76,8 @@ public:
     static const char* MessageName(UINT uMsg);
 
 private:
+    void DispatchScriptToView(Core::PrismaViewId viewId, const std::string& script);
+    bool IsTextInputFocused() const;
     void UpdateStateImpl(Core::PrismaViewId viewId);
 
     HIMC m_context = nullptr;

--- a/src/PrismaUI/InputHandler.cpp
+++ b/src/PrismaUI/InputHandler.cpp
@@ -6,7 +6,6 @@
 #include "Core.h"
 #include "ImeHelper.h"
 #include "Utils/Encoding.h"
-#include "ViewManager.h"
 #pragma comment(lib, "comctl32.lib")
 
 namespace PrismaUI::InputHandler {
@@ -40,6 +39,80 @@ namespace PrismaUI::InputHandler {
     static std::mutex g_wndProcMutex;                        // Thread-safe installation
 
     static ImeHelper g_imeHelper;
+    static std::atomic<bool> g_isFocusedTextInputActive = false;
+
+    constexpr const char* IME_FOCUS_CALLBACK_NAME = "__prismaNativeImeFocusChanged";
+
+    std::string BuildImeFocusTrackingScript() {
+        const std::string callbackName = IME_FOCUS_CALLBACK_NAME;
+        return "(function(){"
+               "if(window.__prismaImeFocusTrackingInstalled){"
+               "if(typeof window.__prismaImeFocusNotify==='function'){window.__prismaImeFocusNotify(document.activeElement);}"
+               "return;"
+               "}"
+               "function isTextInputElement(el){"
+               "if(!el||el.disabled||el.readOnly)return false;"
+               "if(el.isContentEditable)return true;"
+               "var tag=(el.tagName||'').toUpperCase();"
+               "if(tag==='TEXTAREA')return true;"
+               "if(tag!=='INPUT')return false;"
+               "var type=((el.type||'text')+'').toLowerCase();"
+               "switch(type){"
+               "case '':case 'text':case 'search':case 'url':case 'tel':case 'password':case 'email':case 'number':"
+               "return true;"
+               "default:return false;"
+               "}"
+               "}"
+               "function notify(element){"
+               "var focused=isTextInputElement(element)?'1':'0';"
+               "if(typeof window['" + callbackName + "']==='function'){window['" + callbackName + "'](focused);}"
+               "}"
+               "window.__prismaImeFocusNotify=notify;"
+               "window.__prismaImeFocusTrackingInstalled=true;"
+               "document.addEventListener('focusin',function(event){notify(event.target);},true);"
+               "document.addEventListener('focusout',function(){setTimeout(function(){notify(document.activeElement);},0);},true);"
+               "notify(document.activeElement);"
+               "})();";
+    }
+
+    void InstallImeFocusTrackingForView(const Core::PrismaViewId& viewId) {
+        if (!g_ultralightThreadExecutor || !g_viewsMap || !g_viewsMapMutex || viewId == 0) {
+            return;
+        }
+
+        auto install = [viewId]() {
+            std::shared_ptr<Core::PrismaView> viewData = nullptr;
+            {
+                std::shared_lock lock(*g_viewsMapMutex);
+                auto it = g_viewsMap->find(viewId);
+                if (it != g_viewsMap->end()) {
+                    viewData = it->second;
+                }
+            }
+
+            if (!viewData || !viewData->ultralightView || !viewData->isLoadingFinished.load()) {
+                return;
+            }
+
+            Communication::BindJSCallbacks(viewId);
+
+            try {
+                ultralight::String script = BuildImeFocusTrackingScript().c_str();
+                viewData->ultralightView->EvaluateScript(script, nullptr, "");
+            } catch (const std::exception& e) {
+                logger::error("Failed to install IME focus tracking for View [{}]: {}", viewId, e.what());
+            } catch (...) {
+                logger::error("Failed to install IME focus tracking for View [{}]: unknown exception", viewId);
+            }
+        };
+
+        if (g_ultralightThreadExecutor->IsWorkerThread()) {
+            install();
+            return;
+        }
+
+        g_ultralightThreadExecutor->submit(install);
+    }
 
     // Clipboard helper functions
     std::string EscapeForJS(const std::string& text) {
@@ -435,6 +508,11 @@ namespace PrismaUI::InputHandler {
 
     LRESULT CALLBACK SubclassProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam, UINT_PTR uIdSubclass,
                                   DWORD_PTR /*dwRefData*/) {
+        LRESULT imeControlResult = 0;
+        if (g_imeHelper.HandleControlMessage(hwnd, uMsg, wParam, lParam, &imeControlResult)) {
+            return imeControlResult;
+        }
+
         if (uMsg == WM_IME_SETCONTEXT) {
             LPARAM imeLParam = lParam;
             g_imeHelper.ModifySetContextLParam(&imeLParam, uMsg);
@@ -460,7 +538,7 @@ namespace PrismaUI::InputHandler {
                     case WM_KEYDOWN: {
                         // Handle Ctrl+V (Paste)
                         if ((GetKeyState(VK_CONTROL) & 0x8000) && wParam == 'V') {
-                            bool viewHasInputFieldFocus = ViewManager::ViewHasInputFocus(focusedViewIdCopy);
+                            const bool viewHasInputFieldFocus = g_isFocusedTextInputActive.load();
                             if (viewHasInputFieldFocus) {
                                 try {
                                     std::string clipboardText = GetClipboardText();
@@ -557,7 +635,7 @@ namespace PrismaUI::InputHandler {
                         break;
                     }
                     case WM_CHAR: {
-                        bool viewHasInputFieldFocus = ViewManager::ViewHasInputFocus(focusedViewIdCopy);
+                        const bool viewHasInputFieldFocus = g_isFocusedTextInputActive.load();
                         if (viewHasInputFieldFocus) {
                             handledByUI = true;
 
@@ -590,7 +668,7 @@ namespace PrismaUI::InputHandler {
                             return TRUE;
                         }
 
-                        bool viewHasInputFieldFocus = ViewManager::ViewHasInputFocus(focusedViewIdCopy);
+                        const bool viewHasInputFieldFocus = g_isFocusedTextInputActive.load();
                         if (viewHasInputFieldFocus) {
                             handledByUI = true;
 
@@ -633,6 +711,7 @@ namespace PrismaUI::InputHandler {
         g_viewsMap = viewsMap;
         g_viewsMapMutex = viewsMapMutex;
         g_isAnyInputCaptureActive = false;
+        g_isFocusedTextInputActive = false;
         {
             std::lock_guard lock(g_focusedViewIdMutex);
             g_currentlyFocusedViewId = 0;
@@ -647,7 +726,7 @@ namespace PrismaUI::InputHandler {
             [](const std::wstring& ws, LPARAM lp) { QueueCommittedCharEvent(ws, lp); },
             [](const wchar_t* p, int len) { return ConvertUtf16ToUtf8(p, len); });
         g_imeHelper.SetContext({g_hWnd, g_viewsMap, g_viewsMapMutex, &g_focusedViewIdMutex,
-                                &g_currentlyFocusedViewId, &g_isAnyInputCaptureActive});
+                                &g_currentlyFocusedViewId, &g_isAnyInputCaptureActive, &g_isFocusedTextInputActive});
         g_imeHelper.SetExecutor(g_ultralightThreadExecutor);
         g_imeHelper.Initialize(g_hWnd);
 
@@ -727,7 +806,34 @@ namespace PrismaUI::InputHandler {
             logger::debug("PrismaUI Input Capture System Enabled for View [{}].", viewId);
         }
 
-        g_imeHelper.UpdateStateForFocusedView(viewId);
+        g_isFocusedTextInputActive.store(false);
+        g_imeHelper.SetAssociation(false);
+
+        Communication::RegisterJSListener(viewId, IME_FOCUS_CALLBACK_NAME, [viewId](std::string focused) {
+            Core::PrismaViewId currentFocusedViewId = 0;
+            {
+                std::lock_guard lock(g_focusedViewIdMutex);
+                currentFocusedViewId = g_currentlyFocusedViewId;
+            }
+
+            if (currentFocusedViewId != viewId) {
+                return;
+            }
+
+            const bool isTextInputFocused = focused == "1";
+            const bool isCaptureActive = g_isAnyInputCaptureActive.load();
+            g_isFocusedTextInputActive.store(isTextInputFocused);
+            g_imeHelper.SetAssociation(isCaptureActive && isTextInputFocused);
+
+            if (!isTextInputFocused && g_ultralightThreadExecutor) {
+                g_ultralightThreadExecutor->submit([viewId]() {
+                    g_imeHelper.ClearStateInJS(viewId);
+                });
+            } else if (!isTextInputFocused) {
+                g_imeHelper.ClearStateInJS(viewId);
+            }
+        });
+        InstallImeFocusTrackingForView(viewId);
 
         g_mouseButtonStates[0] = g_mouseButtonStates[1] = g_mouseButtonStates[2] = false;
     }
@@ -748,9 +854,7 @@ namespace PrismaUI::InputHandler {
 
         if (disableSystem) {
             if (g_isAnyInputCaptureActive.exchange(false)) {
-                if (currentFocusedBeforeDisable != 0) {
-                    g_imeHelper.ClearStateInJS(currentFocusedBeforeDisable);
-                }
+                g_isFocusedTextInputActive.store(false);
                 g_imeHelper.SetAssociation(false);
                 logger::debug("PrismaUI Input Capture System Disabled (was active for View [{}]).",
                               currentFocusedBeforeDisable);
@@ -789,6 +893,16 @@ namespace PrismaUI::InputHandler {
         }
     }
 
+    void ClearImeState(const Core::PrismaViewId& viewId) {
+        if (viewId == 0) {
+            return;
+        }
+
+        g_isFocusedTextInputActive.store(false);
+        g_imeHelper.SetAssociation(false);
+        g_imeHelper.ClearStateInJS(viewId);
+    }
+
     bool IsAnyInputCaptureActive() { return g_isAnyInputCaptureActive.load(); }
 
     bool IsInputCaptureActiveForView(const Core::PrismaViewId& viewId) {
@@ -825,8 +939,6 @@ namespace PrismaUI::InputHandler {
         }
 
         g_ultralightThreadExecutor->submit([viewId_copy = focusedViewIdCopy, ev_queue = std::move(eventsToProcess)]() {
-            g_imeHelper.UpdateStateForFocusedView(viewId_copy);
-
             std::shared_ptr<Core::PrismaView> targetViewData = nullptr;
             {
                 std::shared_lock lock(*g_viewsMapMutex);
@@ -935,6 +1047,7 @@ namespace PrismaUI::InputHandler {
         g_ultralightThreadExecutor = nullptr;
         g_viewsMap = nullptr;
         g_viewsMapMutex = nullptr;
+        g_isFocusedTextInputActive = false;
         logger::info("PrismaUI::InputHandler Shutdown.");
     }
 }

--- a/src/PrismaUI/InputHandler.h
+++ b/src/PrismaUI/InputHandler.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include "Utils/WinKeyHandler/WinKeyHandler.h"
 
@@ -37,6 +37,7 @@ namespace PrismaUI::InputHandler {
 
     void EnableInputCapture(const Core::PrismaViewId& viewId);
     void DisableInputCapture(const Core::PrismaViewId& viewId);
+    void ClearImeState(const Core::PrismaViewId& viewId);
 
     bool IsInputCaptureActiveForView(const Core::PrismaViewId& viewId);
 

--- a/src/PrismaUI/ViewManager.cpp
+++ b/src/PrismaUI/ViewManager.cpp
@@ -81,6 +81,9 @@ namespace PrismaUI::ViewManager {
         }
 
         PrismaUI::InputHandler::DisableInputCapture(viewId);
+        if (closeFocusMenu) {
+            PrismaUI::InputHandler::ClearImeState(viewId);
+        }
         viewData->ultralightView->Unfocus();
 
         if (closeFocusMenu) {


### PR DESCRIPTION
### Problem
https://github.com/PrismaUI-SKSE/framework/pull/23 introduced a regression where interacting with Prisma UI elements could cause freezes. The freezes were caused by the new IME focus management, which I had added to prevent the system IME window from appearing while text input elements were unfocused. The approach was prone to deadlocking and freezing the game.

### Changes
Replaced the focus/state updates with safer DOM-driven signals and refactored the IME enable/disable part to avoid the SKSE AddTask call.

- removed `ViewHasInputFocus()` polling from IME handling and character input
- removed per-event IME focus/state updates
- removed the old focus-transition IME management path that caused stalls
- replaced native focus probing with a cached DOM-driven text-focus signal from injected `focusin` / `focusout` listeners
- replaced IME association/disassociation logic with posted window-thread messages, instead of the old task-based path

### Testing Done
Testing using ColdSun's Tailor mod.

- no freezes when clicking between Prisma UI elements (scrolling through the blacklist, typing in the filter, and hitting the Back button)
- no freezes when hiding/unfocusing the UI (shift-Z several times in a row)
- native system IME still stays hidden when Prisma UI is not open or a text input is not focused
- custom IME events still work when a text input is focused