### PR TITLE
fix: iframe text input (IME)

### DIFF
--- a/IME_SUPPORT.md
+++ b/IME_SUPPORT.md
@@ -22,7 +22,7 @@ window.addEventListener('prismaIME_state', (e) => {
 
 The **payload is in `event.detail`** - use it as the full IME state object.
 
-The event should be treated as a full snapshot, not a delta. Expect it to update whenever the visible IME state changes while the text field is active, including:
+The event should be treated as a full snapshot, not a delta. Expect it to update whenever the visible IME state changes while PrismaUI has input capture, including:
 
 - composition start
 - composition text changes
@@ -49,6 +49,8 @@ Field meanings:
 - `caret`: zero-based caret position inside `composition`; use it to split the composition string and draw an inline caret
 - `candidates`: the currently visible candidate page
 - `selectedIndex`: zero-based index of the highlighted candidate within `candidates`; use `-1` when there is no valid selection
+
+**Focus:** PrismaUI does not tie these events to which DOM control is focused. Updates can arrive even when no text input in your page has focus. Your app should track focus on your own text fields (including iframes or custom widgets) and only show the custom overlay when it makes sense.
 
 ## Step 2: Render A Custom Overlay
 

--- a/src/PrismaUI/ImeHelper.cpp
+++ b/src/PrismaUI/ImeHelper.cpp
@@ -6,8 +6,6 @@
 
 #include "Communication.h"
 #include "Core.h"
-#include "ViewManager.h"
-
 namespace PrismaUI {
 
 namespace {
@@ -97,13 +95,9 @@ void ImeHelper::Initialize(HWND hwnd) {
         }
     }
 
-    // Start with IME disassociated. The active text input state drives
-    // association via posted window-thread messages.
+    // Start with IME disassociated. Prisma input capture drives association
+    // via posted window-thread messages.
     m_associated = false;
-}
-
-bool ImeHelper::IsTextInputFocused() const {
-    return m_ctx.isTextInputFocused && m_ctx.isTextInputFocused->load();
 }
 
 void ImeHelper::DispatchScriptToView(Core::PrismaViewId viewId, const std::string& script) {
@@ -141,7 +135,6 @@ void ImeHelper::DispatchScriptToView(Core::PrismaViewId viewId, const std::strin
 void ImeHelper::Shutdown(HWND hwnd) {
     if (!m_context) return;
 
-    m_lastKnownTextInputFocus = false;
     m_associated = false;
     if (hwnd) {
         ImmAssociateContext(hwnd, nullptr);
@@ -345,7 +338,6 @@ bool ImeHelper::HandleMessage(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
     if (!outHandled || focusedViewId == 0) return false;
 
     if (!m_associated.load()) return false;
-    if (!IsTextInputFocused()) return false;
 
     switch (uMsg) {
         case WM_IME_STARTCOMPOSITION:
@@ -388,46 +380,6 @@ bool ImeHelper::HandleMessage(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
         default:
             return false;
     }
-}
-
-void ImeHelper::UpdateStateImpl(Core::PrismaViewId viewId) {
-    if (!m_ctx.viewsMap || !m_ctx.viewsMapMutex || viewId == 0) {
-        m_lastKnownTextInputFocus = false;
-        return;
-    }
-
-    bool stillFocused = false;
-    if (m_ctx.focusedViewIdMutex && m_ctx.currentlyFocusedViewId && m_ctx.isAnyInputCaptureActive) {
-        std::lock_guard lock(*m_ctx.focusedViewIdMutex);
-        stillFocused =
-            m_ctx.isAnyInputCaptureActive->load() && *m_ctx.currentlyFocusedViewId == viewId;
-    }
-
-    if (!stillFocused) {
-        m_lastKnownTextInputFocus = false;
-        ClearStateInJS(viewId);
-        return;
-    }
-
-    const bool textInputFocused = IsTextInputFocused();
-    m_lastKnownTextInputFocus = textInputFocused;
-
-    if (!textInputFocused) {
-        ClearStateInJS(viewId);
-    }
-}
-
-void ImeHelper::UpdateStateForFocusedView(Core::PrismaViewId viewId) {
-    if (!m_executor) return;
-
-    if (m_executor->IsWorkerThread()) {
-        UpdateStateImpl(viewId);
-        return;
-    }
-
-    m_executor->submit_with_priority(
-        SingleThreadExecutor::Priority::HIGH,
-        [this, viewId]() { UpdateStateImpl(viewId); });
 }
 
 }  // namespace PrismaUI

--- a/src/PrismaUI/ImeHelper.h
+++ b/src/PrismaUI/ImeHelper.h
@@ -18,15 +18,11 @@ using ImeEscapeForJSCallback = std::function<std::string(const std::string&)>;
 using ImeQueueCommittedCharCallback = std::function<void(const std::wstring&, LPARAM)>;
 using ImeConvertUtf16ToUtf8Callback = std::function<std::string(const wchar_t*, int)>;
 
-// Context references for focus/IME state checks
+// Context references for IME state dispatch and window ownership.
 struct ImeHelperContext {
     HWND hwnd = nullptr;
     std::map<Core::PrismaViewId, std::shared_ptr<Core::PrismaView>>* viewsMap = nullptr;
     std::shared_mutex* viewsMapMutex = nullptr;
-    std::mutex* focusedViewIdMutex = nullptr;
-    Core::PrismaViewId* currentlyFocusedViewId = nullptr;
-    std::atomic<bool>* isAnyInputCaptureActive = nullptr;
-    std::atomic<bool>* isTextInputFocused = nullptr;
 };
 
 // Custom IME composition support: reads Windows IME state and dispatches to JS
@@ -51,10 +47,6 @@ public:
     // Associate/unassociate IME context with window. Must run on main thread for ImmAssociateContext.
     void SetAssociation(bool enabled);
 
-    // Update IME state based on focused view and text input focus. Call from ultralight thread
-    // or via executor.
-    void UpdateStateForFocusedView(Core::PrismaViewId viewId);
-
     // Send current IME composition/candidate state to JS, or clear it.
     void SendStateToJS(Core::PrismaViewId viewId, HWND hwnd, bool active);
     void ClearStateInJS(Core::PrismaViewId viewId);
@@ -77,13 +69,10 @@ public:
 
 private:
     void DispatchScriptToView(Core::PrismaViewId viewId, const std::string& script);
-    bool IsTextInputFocused() const;
-    void UpdateStateImpl(Core::PrismaViewId viewId);
 
     HIMC m_context = nullptr;
     bool m_contextOwned = false;
     std::atomic<bool> m_associated{false};
-    std::atomic<bool> m_lastKnownTextInputFocus{false};
 
     ImeEscapeForJSCallback m_escapeForJS;
     ImeQueueCommittedCharCallback m_queueCommittedChar;

--- a/src/PrismaUI/InputHandler.cpp
+++ b/src/PrismaUI/InputHandler.cpp
@@ -39,80 +39,6 @@ namespace PrismaUI::InputHandler {
     static std::mutex g_wndProcMutex;                        // Thread-safe installation
 
     static ImeHelper g_imeHelper;
-    static std::atomic<bool> g_isFocusedTextInputActive = false;
-
-    constexpr const char* IME_FOCUS_CALLBACK_NAME = "__prismaNativeImeFocusChanged";
-
-    std::string BuildImeFocusTrackingScript() {
-        const std::string callbackName = IME_FOCUS_CALLBACK_NAME;
-        return "(function(){"
-               "if(window.__prismaImeFocusTrackingInstalled){"
-               "if(typeof window.__prismaImeFocusNotify==='function'){window.__prismaImeFocusNotify(document.activeElement);}"
-               "return;"
-               "}"
-               "function isTextInputElement(el){"
-               "if(!el||el.disabled||el.readOnly)return false;"
-               "if(el.isContentEditable)return true;"
-               "var tag=(el.tagName||'').toUpperCase();"
-               "if(tag==='TEXTAREA')return true;"
-               "if(tag!=='INPUT')return false;"
-               "var type=((el.type||'text')+'').toLowerCase();"
-               "switch(type){"
-               "case '':case 'text':case 'search':case 'url':case 'tel':case 'password':case 'email':case 'number':"
-               "return true;"
-               "default:return false;"
-               "}"
-               "}"
-               "function notify(element){"
-               "var focused=isTextInputElement(element)?'1':'0';"
-               "if(typeof window['" + callbackName + "']==='function'){window['" + callbackName + "'](focused);}"
-               "}"
-               "window.__prismaImeFocusNotify=notify;"
-               "window.__prismaImeFocusTrackingInstalled=true;"
-               "document.addEventListener('focusin',function(event){notify(event.target);},true);"
-               "document.addEventListener('focusout',function(){setTimeout(function(){notify(document.activeElement);},0);},true);"
-               "notify(document.activeElement);"
-               "})();";
-    }
-
-    void InstallImeFocusTrackingForView(const Core::PrismaViewId& viewId) {
-        if (!g_ultralightThreadExecutor || !g_viewsMap || !g_viewsMapMutex || viewId == 0) {
-            return;
-        }
-
-        auto install = [viewId]() {
-            std::shared_ptr<Core::PrismaView> viewData = nullptr;
-            {
-                std::shared_lock lock(*g_viewsMapMutex);
-                auto it = g_viewsMap->find(viewId);
-                if (it != g_viewsMap->end()) {
-                    viewData = it->second;
-                }
-            }
-
-            if (!viewData || !viewData->ultralightView || !viewData->isLoadingFinished.load()) {
-                return;
-            }
-
-            Communication::BindJSCallbacks(viewId);
-
-            try {
-                ultralight::String script = BuildImeFocusTrackingScript().c_str();
-                viewData->ultralightView->EvaluateScript(script, nullptr, "");
-            } catch (const std::exception& e) {
-                logger::error("Failed to install IME focus tracking for View [{}]: {}", viewId, e.what());
-            } catch (...) {
-                logger::error("Failed to install IME focus tracking for View [{}]: unknown exception", viewId);
-            }
-        };
-
-        if (g_ultralightThreadExecutor->IsWorkerThread()) {
-            install();
-            return;
-        }
-
-        g_ultralightThreadExecutor->submit(install);
-    }
 
     // Clipboard helper functions
     std::string EscapeForJS(const std::string& text) {
@@ -538,30 +464,27 @@ namespace PrismaUI::InputHandler {
                     case WM_KEYDOWN: {
                         // Handle Ctrl+V (Paste)
                         if ((GetKeyState(VK_CONTROL) & 0x8000) && wParam == 'V') {
-                            const bool viewHasInputFieldFocus = g_isFocusedTextInputActive.load();
-                            if (viewHasInputFieldFocus) {
-                                try {
-                                    std::string clipboardText = GetClipboardText();
-                                    if (!clipboardText.empty()) {
-                                        logger::debug("Ctrl+V: Pasting {} characters from clipboard",
-                                                      clipboardText.length());
+                            try {
+                                std::string clipboardText = GetClipboardText();
+                                if (!clipboardText.empty()) {
+                                    logger::debug("Ctrl+V: Pasting {} characters from clipboard",
+                                                  clipboardText.length());
 
-                                        // Escape text for JavaScript string
-                                        std::string escapedText = EscapeForJS(clipboardText);
+                                    // Escape text for JavaScript string
+                                    std::string escapedText = EscapeForJS(clipboardText);
 
-                                        if (escapedText.empty() && !clipboardText.empty()) {
-                                            logger::warn("Failed to escape clipboard text, paste cancelled");
-                                        } else if (!escapedText.empty()) {
-                                            // Use JavaScript execCommand to insert text properly (handles UTF-8)
-                                            std::string script =
-                                                "document.execCommand('insertText', false, '" + escapedText + "')";
+                                    if (escapedText.empty() && !clipboardText.empty()) {
+                                        logger::warn("Failed to escape clipboard text, paste cancelled");
+                                    } else if (!escapedText.empty()) {
+                                        // Use JavaScript execCommand to insert text properly (handles UTF-8)
+                                        std::string script =
+                                            "document.execCommand('insertText', false, '" + escapedText + "')";
 
-                                            PrismaUI::Communication::Invoke(focusedViewIdCopy, script.c_str());
-                                        }
+                                        PrismaUI::Communication::Invoke(focusedViewIdCopy, script.c_str());
                                     }
-                                } catch (const std::exception& e) {
-                                    logger::error("Exception during paste operation: {}", e.what());
                                 }
+                            } catch (const std::exception& e) {
+                                logger::error("Exception during paste operation: {}", e.what());
                             }
                             handledByUI = true;
                             break;
@@ -635,32 +558,27 @@ namespace PrismaUI::InputHandler {
                         break;
                     }
                     case WM_CHAR: {
-                        const bool viewHasInputFieldFocus = g_isFocusedTextInputActive.load();
-                        if (viewHasInputFieldFocus) {
-                            handledByUI = true;
+                        handledByUI = true;
 
-                            wchar_t ch = static_cast<wchar_t>(wParam);
-                            if (IsHighSurrogate(ch)) {
-                                g_pendingHighSurrogate = ch;
-                                break;
-                            }
+                        wchar_t ch = static_cast<wchar_t>(wParam);
+                        if (IsHighSurrogate(ch)) {
+                            g_pendingHighSurrogate = ch;
+                            break;
+                        }
 
-                            std::wstring committedText;
-                            if (IsLowSurrogate(ch) && g_pendingHighSurrogate != 0) {
-                                committedText.push_back(g_pendingHighSurrogate);
-                                committedText.push_back(ch);
-                                g_pendingHighSurrogate = 0;
-                            } else {
-                                g_pendingHighSurrogate = 0;
-                                if (ShouldQueueChar(ch)) {
-                                    committedText.push_back(ch);
-                                }
-                            }
-
-                            QueueCommittedCharEvent(committedText, lParam);
+                        std::wstring committedText;
+                        if (IsLowSurrogate(ch) && g_pendingHighSurrogate != 0) {
+                            committedText.push_back(g_pendingHighSurrogate);
+                            committedText.push_back(ch);
+                            g_pendingHighSurrogate = 0;
                         } else {
                             g_pendingHighSurrogate = 0;
+                            if (ShouldQueueChar(ch)) {
+                                committedText.push_back(ch);
+                            }
                         }
+
+                        QueueCommittedCharEvent(committedText, lParam);
                         break;
                     }
                     case WM_UNICHAR: {
@@ -668,15 +586,12 @@ namespace PrismaUI::InputHandler {
                             return TRUE;
                         }
 
-                        const bool viewHasInputFieldFocus = g_isFocusedTextInputActive.load();
-                        if (viewHasInputFieldFocus) {
-                            handledByUI = true;
+                        handledByUI = true;
 
-                            std::wstring committedText = ConvertCodePointToUtf16(static_cast<UINT>(wParam));
-                            if (!committedText.empty() && ShouldQueueChar(committedText[0])) {
-                                g_pendingHighSurrogate = 0;
-                                QueueCommittedCharEvent(committedText, lParam);
-                            }
+                        std::wstring committedText = ConvertCodePointToUtf16(static_cast<UINT>(wParam));
+                        if (!committedText.empty() && ShouldQueueChar(committedText[0])) {
+                            g_pendingHighSurrogate = 0;
+                            QueueCommittedCharEvent(committedText, lParam);
                         }
                         break;
                     }
@@ -711,7 +626,6 @@ namespace PrismaUI::InputHandler {
         g_viewsMap = viewsMap;
         g_viewsMapMutex = viewsMapMutex;
         g_isAnyInputCaptureActive = false;
-        g_isFocusedTextInputActive = false;
         {
             std::lock_guard lock(g_focusedViewIdMutex);
             g_currentlyFocusedViewId = 0;
@@ -725,8 +639,7 @@ namespace PrismaUI::InputHandler {
             [](const std::string& s) { return EscapeForJS(s); },
             [](const std::wstring& ws, LPARAM lp) { QueueCommittedCharEvent(ws, lp); },
             [](const wchar_t* p, int len) { return ConvertUtf16ToUtf8(p, len); });
-        g_imeHelper.SetContext({g_hWnd, g_viewsMap, g_viewsMapMutex, &g_focusedViewIdMutex,
-                                &g_currentlyFocusedViewId, &g_isAnyInputCaptureActive, &g_isFocusedTextInputActive});
+        g_imeHelper.SetContext({g_hWnd, g_viewsMap, g_viewsMapMutex});
         g_imeHelper.SetExecutor(g_ultralightThreadExecutor);
         g_imeHelper.Initialize(g_hWnd);
 
@@ -792,7 +705,6 @@ namespace PrismaUI::InputHandler {
             logger::warn("EnableInputCapture called with empty viewId.");
             return;
         }
-        bool firstTimeActivation = false;
         {
             std::lock_guard lock(g_focusedViewIdMutex);
             if (g_currentlyFocusedViewId != viewId) {
@@ -802,38 +714,10 @@ namespace PrismaUI::InputHandler {
         }
 
         if (!g_isAnyInputCaptureActive.exchange(true)) {
-            firstTimeActivation = true;
             logger::debug("PrismaUI Input Capture System Enabled for View [{}].", viewId);
         }
 
-        g_isFocusedTextInputActive.store(false);
-        g_imeHelper.SetAssociation(false);
-
-        Communication::RegisterJSListener(viewId, IME_FOCUS_CALLBACK_NAME, [viewId](std::string focused) {
-            Core::PrismaViewId currentFocusedViewId = 0;
-            {
-                std::lock_guard lock(g_focusedViewIdMutex);
-                currentFocusedViewId = g_currentlyFocusedViewId;
-            }
-
-            if (currentFocusedViewId != viewId) {
-                return;
-            }
-
-            const bool isTextInputFocused = focused == "1";
-            const bool isCaptureActive = g_isAnyInputCaptureActive.load();
-            g_isFocusedTextInputActive.store(isTextInputFocused);
-            g_imeHelper.SetAssociation(isCaptureActive && isTextInputFocused);
-
-            if (!isTextInputFocused && g_ultralightThreadExecutor) {
-                g_ultralightThreadExecutor->submit([viewId]() {
-                    g_imeHelper.ClearStateInJS(viewId);
-                });
-            } else if (!isTextInputFocused) {
-                g_imeHelper.ClearStateInJS(viewId);
-            }
-        });
-        InstallImeFocusTrackingForView(viewId);
+        g_imeHelper.SetAssociation(true);
 
         g_mouseButtonStates[0] = g_mouseButtonStates[1] = g_mouseButtonStates[2] = false;
     }
@@ -854,7 +738,6 @@ namespace PrismaUI::InputHandler {
 
         if (disableSystem) {
             if (g_isAnyInputCaptureActive.exchange(false)) {
-                g_isFocusedTextInputActive.store(false);
                 g_imeHelper.SetAssociation(false);
                 logger::debug("PrismaUI Input Capture System Disabled (was active for View [{}]).",
                               currentFocusedBeforeDisable);
@@ -898,7 +781,6 @@ namespace PrismaUI::InputHandler {
             return;
         }
 
-        g_isFocusedTextInputActive.store(false);
         g_imeHelper.SetAssociation(false);
         g_imeHelper.ClearStateInJS(viewId);
     }
@@ -1047,7 +929,6 @@ namespace PrismaUI::InputHandler {
         g_ultralightThreadExecutor = nullptr;
         g_viewsMap = nullptr;
         g_viewsMapMutex = nullptr;
-        g_isFocusedTextInputActive = false;
         logger::info("PrismaUI::InputHandler Shutdown.");
     }
 }


### PR DESCRIPTION
Removes the input element filtering for IME state changes that was added in #25 .

## Problem
In order to hide the system IME window when text elements are focused / unfocused, I had added javascript tracking for inputs and textarea focus events. However, that didn't work with iframes, which at least some Prisma UI mods are dependent on, resulting in text input not working (being filtered out) within iframes.

## Changes
Removed the per-element focus tracking from the IME support. This reverts the behavior to be much closer to the 1.3 state, plus the json IME state event for custom UI mods to use.

This is a slight loss of behavior for IME input, as described in the following scenario, but not a big change.
Scenario: User unfocuses a text input (clicks a panel), then types, then refocuses the text input.
Before: IME state is reset automatically - no composition is shown in the text input (track when input was focused, clear state)
After: IME state is not reset. On re-focusing the text input, the IME state event shows the text that was typed while nothing was in focus.

This could be mitigated by providing an API to clear IME state, with the consumer mod calling it on-demand when their text elements gain/lose focus. But it seems pretty minor, not sure this is needed for now.

## Testing done
- SkyrimNet: with its chat input, can type in Japanese and see that mod's custom IME overlay. System IME does not appear when typing while text elements are unfocused.
- SkyrimNet Prisma Dashboard plugin: This mod shows a webpage inside an iframe. Text input works inside this page (broken before this PR).
- Tailor: Still no freezes when using the mod, switching focus between elements.