### PR TITLE
Added Gamepad Support

### DIFF
--- a/src/PrismaUI/GamepadInputHandler.cpp
+++ b/src/PrismaUI/GamepadInputHandler.cpp
@@ -1,0 +1,311 @@
+#include "GamepadInputHandler.h"
+
+// Ultralight headers trip C4100 (unreferenced formal parameter); silence it for them only.
+#pragma warning(push)
+#pragma warning(disable : 4100)
+#include <Ultralight/Ultralight.h>
+#pragma warning(pop)
+
+#include <atomic>
+#include <mutex>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "Communication.h"
+#include "Core.h"
+#include "InputHandler.h"
+#include "PrismaVR.h"
+#include "Utils/SingleThreadExecutor.h"
+
+// Gamepad Support: Ultralight will not automatically detect a gamepad.
+// This code uses BSInputDeviceManager to monitor button presses.
+// It informs Ultralight via Renderer::FireGamepad* so navigator.getGamepads() can function normally.
+// The controller is always at index 0 and mimicks the standard W3C controller:
+// https://www.w3.org/TR/gamepad/#remapping
+//
+// Threading: input is captured and queued on the game's input thread; the queue is drained and
+// fired on the Renderer from the Ultralight thread, because Renderer calls are single-threaded.
+namespace PrismaUI::GamepadInputHandler {
+    namespace {
+        constexpr uint32_t GAMEPAD_INDEX = 0;          // The gamepad is always depicted at index 0.
+        constexpr uint32_t GAMEPAD_AXIS_COUNT = 4;     // W3C standard gamepad with left and right X and Y axes
+        constexpr uint32_t GAMEPAD_BUTTON_COUNT = 17;  // W3C standard gamepad with 17 buttons
+
+        // A queued gamepad event: a button change or an axis change.
+        using GamepadQueuedEvent = std::variant<ultralight::GamepadButtonEvent, ultralight::GamepadAxisEvent>;
+        std::mutex g_gamepadQueueMutex;  // Guards g_gamepadQueue across the input and Ultralight threads
+        std::vector<GamepadQueuedEvent>
+            g_gamepadQueue;  // Input thread adds to this vector. Ultralight thread consumes.
+
+        // Allows execution on the Ultralight thread. Calls Core::Renderer. Owned by InputHandler.
+        SingleThreadExecutor* g_ultralightThreadExecutor = nullptr;
+        // Ensure virtual gamepad is declared to the Renderer once upon the first input.
+        std::atomic<bool> g_gamepadRegistered = false;
+        float g_gamepadButtonValues[GAMEPAD_BUTTON_COUNT] = {};  // Last observed value per button.
+
+        // Converts Skyrim ID Code to W3C index (-1 if not recognized, e.g., guide button)
+        int SkyrimIDCodeToW3CIndex(uint32_t skyrimCode) {
+            using Key = RE::BSWin32GamepadDevice::Key;
+            return skyrimCode == Key::kA               ? 0
+                   : skyrimCode == Key::kB             ? 1
+                   : skyrimCode == Key::kX             ? 2
+                   : skyrimCode == Key::kY             ? 3
+                   : skyrimCode == Key::kLeftShoulder  ? 4
+                   : skyrimCode == Key::kRightShoulder ? 5
+                   : skyrimCode == Key::kLeftTrigger   ? 6  // analog
+                   : skyrimCode == Key::kRightTrigger  ? 7  // analog
+                   : skyrimCode == Key::kBack          ? 8
+                   : skyrimCode == Key::kStart         ? 9
+                   : skyrimCode == Key::kLeftThumb     ? 10
+                   : skyrimCode == Key::kRightThumb    ? 11
+                   : skyrimCode == Key::kUp            ? 12
+                   : skyrimCode == Key::kDown          ? 13
+                   : skyrimCode == Key::kLeft          ? 14
+                   : skyrimCode == Key::kRight         ? 15
+                                                       : -1;
+        }
+
+        // Resolves the menu role of the button via the control map and dispatches a named CustomEvent
+        // (detail: { w3cButtonIndex: number, skyrimIdCode: number, action: string }) to the focused view.
+        // eventName is "prismagamepadbuttondown" on a press or "prismagamepadbuttonup" on a release.
+        void DispatchButtonEvent(const char* eventName, uint32_t w3cButtonIndex, uint32_t skyrimIDCode) {
+            const Core::PrismaViewId viewId = InputHandler::GetFocusedViewId();
+            if (viewId == 0) {
+                return;
+            }
+
+            const char* action = "";
+            if (auto* controlMap = RE::ControlMap::GetSingleton()) {
+                using Context = RE::ControlMap::InputContextID;
+                const uint32_t acceptIDCode =
+                    controlMap->GetMappedKey("Accept", RE::INPUT_DEVICE::kGamepad, Context::kMenuMode);
+                if (acceptIDCode == skyrimIDCode) {
+                    action = "accept";
+                } else {
+                    const uint32_t cancelIDCode =
+                        controlMap->GetMappedKey("Cancel", RE::INPUT_DEVICE::kGamepad, Context::kMenuMode);
+                    if (cancelIDCode == skyrimIDCode) {
+                        action = "cancel";
+                    }
+                }
+            }
+
+            const std::string script = std::string("window.dispatchEvent(new CustomEvent(\"") + eventName +
+                                       "\", {detail: {w3cButtonIndex: " + std::to_string(w3cButtonIndex) +
+                                       ", skyrimIdCode: " + std::to_string(skyrimIDCode) + ", action: \"" + action +
+                                       "\"}}))";
+            Communication::Invoke(viewId, script.c_str());
+        }
+
+        // --- Input thread: capture into the queue ---
+
+        // Maps a gamepad button event to the standard layout and queues it, skipping unchanged repeats.
+        void QueueButtonEvent(RE::ButtonEvent* buttonEvent) {
+            const uint32_t buttonIDCode = buttonEvent->GetIDCode();
+            const int w3cButtonIndexInt = SkyrimIDCodeToW3CIndex(buttonIDCode);  // Skyrim code -> W3C index.
+            if (w3cButtonIndexInt < 0) {
+                // Unrecognized input
+                return;
+            }
+
+            const uint32_t w3cButtonIndex = static_cast<uint32_t>(w3cButtonIndexInt);
+
+            // Fire buttondown on the press edge and buttonup on the release edge.
+            if (buttonEvent->IsDown()) {
+                DispatchButtonEvent("prismagamepadbuttondown", w3cButtonIndex, buttonIDCode);
+            } else if (buttonEvent->IsUp()) {
+                DispatchButtonEvent("prismagamepadbuttonup", w3cButtonIndex, buttonIDCode);
+            }
+
+            // A trigger ranges from 0 to 1 (float); a digital button returns 0 or 1.
+            const float value = buttonEvent->Value();
+            if (g_gamepadButtonValues[w3cButtonIndex] == value) {
+                // Button value unchanged since last event. Don't send unnecessarily.
+                return;
+            }
+            // Save button value for future calls to this function.
+            g_gamepadButtonValues[w3cButtonIndex] = value;
+
+            // Build event to be received by the Renderer
+            ultralight::GamepadButtonEvent ev{};
+            ev.index = GAMEPAD_INDEX;
+            ev.button_index = w3cButtonIndex;
+            ev.value = value;
+
+            // Add to gamepad queue so it can be picked up later on the Ultralight thread.
+            std::lock_guard lock(g_gamepadQueueMutex);
+            g_gamepadQueue.emplace_back(ev);
+        }
+
+        // Maps a thumbstick event to its standard axis pair and queues both axes together.
+        void QueueThumbstickEvent(RE::ThumbstickEvent* thumbstickEvent) {
+            // Pick the standard axis pair for whichever stick moved.
+            uint32_t xAxis;
+            uint32_t yAxis;
+            if (thumbstickEvent->IsLeft()) {
+                xAxis = 0;
+                yAxis = 1;
+            } else if (thumbstickEvent->IsRight()) {
+                xAxis = 2;
+                yAxis = 3;
+            } else {
+                // If neither left nor right, ignore.
+                return;
+            }
+
+            // Build x-axis event to be received by the Renderer.
+            ultralight::GamepadAxisEvent xev{};
+            xev.index = GAMEPAD_INDEX;
+            xev.axis_index = xAxis;
+            xev.value = thumbstickEvent->xValue;
+
+            // Build y-axis event to be received by the Renderer.
+            ultralight::GamepadAxisEvent yev{};
+            yev.index = GAMEPAD_INDEX;
+            yev.axis_index = yAxis;
+            // Negate Y: Skyrim reports +up while the W3C standard mapping expects +down.
+            yev.value = -thumbstickEvent->yValue;
+
+            // Add to gamepad queue so it can be picked up later on the Ultralight thread.
+            std::lock_guard lock(g_gamepadQueueMutex);
+            g_gamepadQueue.emplace_back(xev);
+            g_gamepadQueue.emplace_back(yev);
+        }
+
+        // Captures Skyrim gamepad input and queues it for ProcessEvents(). Gated on input capture, like mouse/keyboard.
+        class GamepadEventListener : public RE::BSTEventSink<RE::InputEvent*> {
+        public:
+            static GamepadEventListener* GetSingleton() {
+                // One instance for the process. Its address is used in AddEventSink and RemoveEventSink.
+                static GamepadEventListener singleton;
+                return &singleton;
+            }
+
+            RE::BSEventNotifyControl ProcessEvent(
+                RE::InputEvent* const* a_event,
+                [[maybe_unused]] RE::BSTEventSource<RE::InputEvent*>* a_eventSource) override {
+                // If event is valid, input capture is active, and not VR, queue events.
+                if (a_event && *a_event && InputHandler::IsAnyInputCaptureActive() && !PrismaVR::IsVRActive()) {
+                    for (auto event = *a_event; event; event = event->next) {  // Events arrive as a linked list.
+                        const RE::INPUT_EVENT_TYPE eventType = event->GetEventType();
+                        if (eventType == RE::INPUT_EVENT_TYPE::kButton) {
+                            // For buttons, ensure the device is the gamepad.
+                            auto buttonEvent = event->AsButtonEvent();
+                            if (buttonEvent && buttonEvent->GetDevice() == RE::INPUT_DEVICE::kGamepad) {
+                                QueueButtonEvent(buttonEvent);
+                            }
+                        } else if (eventType == RE::INPUT_EVENT_TYPE::kThumbstick) {
+                            // For thumbsticks, the device is always a gamepad.
+                            if (auto thumbstickEvent = event->AsThumbstickEvent()) {
+                                QueueThumbstickEvent(thumbstickEvent);
+                            }
+                        }
+                    }
+                }
+                return RE::BSEventNotifyControl::kContinue;
+            }
+        };
+
+        // --- Ultralight thread: drain onto the Renderer ---
+
+        // Declares the virtual pad to the Renderer exactly once so navigator.getGamepads() reports it.
+        void EnsureGamepadRegistered() {
+            if (g_gamepadRegistered.exchange(true)) {
+                // If already registered, return.
+                return;
+            }
+            const ultralight::String name = "Skyrim Controller (Standard Mapping)";
+            Core::renderer->SetGamepadDetails(GAMEPAD_INDEX, name, GAMEPAD_AXIS_COUNT, GAMEPAD_BUTTON_COUNT);
+            ultralight::GamepadEvent connectEvent{};
+            connectEvent.type =
+                ultralight::GamepadEvent::kType_GamepadConnected;  // JavaScript "gamepadconnected" event
+            connectEvent.index = GAMEPAD_INDEX;
+            Core::renderer->FireGamepadEvent(connectEvent);
+        }
+
+        // Fires one queued event on the Renderer, picking the call that matches its variant type
+        // This does not trigger any JavaScript event. It just changes gamepad state.
+        void FireGamepadQueuedEvent(const GamepadQueuedEvent& event) {
+            std::visit(
+                [](const auto& arg) {
+                    using T = std::decay_t<decltype(arg)>;
+                    if constexpr (std::is_same_v<T, ultralight::GamepadButtonEvent>) {
+                        Core::renderer->FireGamepadButtonEvent(arg);
+                    } else if constexpr (std::is_same_v<T, ultralight::GamepadAxisEvent>) {
+                        Core::renderer->FireGamepadAxisEvent(arg);
+                    }
+                },
+                event);
+        }
+    }
+
+    void ResetButtonValues() {
+        for (auto& v : g_gamepadButtonValues) {
+            v = 0.0f;
+        }
+    }
+
+    void Initialize(SingleThreadExecutor* ultralightThreadExecutor) {
+        g_ultralightThreadExecutor = ultralightThreadExecutor;
+        g_gamepadRegistered = false;  // Declare the pad to the Renderer on the next input. (The renderer may be new.)
+        ResetButtonValues();          // Start with no inputs pressed
+        {
+            std::lock_guard lock(g_gamepadQueueMutex);
+            g_gamepadQueue.clear();  // Clear any queued events from a previous session.
+        }
+
+        auto inputEventSource = RE::BSInputDeviceManager::GetSingleton();
+        if (inputEventSource) {
+            inputEventSource->AddEventSink(GamepadEventListener::GetSingleton());  // Begin receiving raw input events.
+            logger::info("GamepadEventListener registered with BSInputDeviceManager");
+        } else {
+            logger::error("Failed to register GamepadEventListener: BSInputDeviceManager is null");
+        }
+    }
+
+    // Processes waiting events
+    void ProcessEvents() {
+        if (!g_ultralightThreadExecutor) {
+            return;
+        }
+
+        // Swap the queue out under the lock so it's held only briefly. Then operate on our local copy.
+        std::vector<GamepadQueuedEvent> gamepadEvents;
+        {
+            std::lock_guard lock(g_gamepadQueueMutex);
+            if (g_gamepadQueue.empty()) {
+                // Nothing is queued.
+                return;
+            }
+            // Transfer all queued events to the local queue.
+            gamepadEvents.swap(g_gamepadQueue);
+        }
+
+        // Renderer calls must run on the Ultralight thread, so post the firing there.
+        g_ultralightThreadExecutor->submit([events = std::move(gamepadEvents)]() {
+            if (!Core::renderer) return;  // renderer was torn down between queueing and running.
+            EnsureGamepadRegistered();
+            for (const auto& event : events) {
+                FireGamepadQueuedEvent(event);
+            }
+        });
+    }
+
+    void Shutdown() {
+        auto inputEventSource = RE::BSInputDeviceManager::GetSingleton();
+        if (inputEventSource) {
+            inputEventSource->RemoveEventSink(GamepadEventListener::GetSingleton());  // stop receiving input events.
+            logger::debug("GamepadEventListener removed from BSInputDeviceManager");
+        }
+
+        {
+            std::lock_guard lock(g_gamepadQueueMutex);
+            g_gamepadQueue.clear();  // Clear any unsent events.
+        }
+        g_gamepadRegistered = false;  // Allows a new session to redeclare the gamepad to the new renderer.
+        g_ultralightThreadExecutor = nullptr;
+    }
+}

--- a/src/PrismaUI/GamepadInputHandler.h
+++ b/src/PrismaUI/GamepadInputHandler.h
@@ -1,0 +1,20 @@
+#pragma once
+
+class SingleThreadExecutor;
+
+namespace PrismaUI::GamepadInputHandler {
+    // Registers the gamepad input sink with BSInputDeviceManager and stores the Ultralight thread
+    // executor used to fire events on the Renderer. Call once from InputHandler::Initialize.
+    void Initialize(SingleThreadExecutor* ultralightThreadExecutor);
+
+    // Drains queued gamepad events and fires them on the Renderer.
+    // Call from InputHandler::ProcessEvents.
+    void ProcessEvents();
+
+    // Reset all "held" buttons so the next press registers as a fresh 0 -> 1 change. This function is called on
+    // initialization and focus changes.
+    void ResetButtonValues();
+
+    // Removes the sink and clears queued state.
+    void Shutdown();
+}

--- a/src/PrismaUI/InputHandler.cpp
+++ b/src/PrismaUI/InputHandler.cpp
@@ -4,7 +4,9 @@
 
 #include "Communication.h"
 #include "Core.h"
+#include "GamepadInputHandler.h"
 #include "ImeHelper.h"
+#include "PrismaVR.h"
 #include "Utils/Encoding.h"
 #pragma comment(lib, "comctl32.lib")
 
@@ -39,80 +41,6 @@ namespace PrismaUI::InputHandler {
     static std::mutex g_wndProcMutex;                        // Thread-safe installation
 
     static ImeHelper g_imeHelper;
-    static std::atomic<bool> g_isFocusedTextInputActive = false;
-
-    constexpr const char* IME_FOCUS_CALLBACK_NAME = "__prismaNativeImeFocusChanged";
-
-    std::string BuildImeFocusTrackingScript() {
-        const std::string callbackName = IME_FOCUS_CALLBACK_NAME;
-        return "(function(){"
-               "if(window.__prismaImeFocusTrackingInstalled){"
-               "if(typeof window.__prismaImeFocusNotify==='function'){window.__prismaImeFocusNotify(document.activeElement);}"
-               "return;"
-               "}"
-               "function isTextInputElement(el){"
-               "if(!el||el.disabled||el.readOnly)return false;"
-               "if(el.isContentEditable)return true;"
-               "var tag=(el.tagName||'').toUpperCase();"
-               "if(tag==='TEXTAREA')return true;"
-               "if(tag!=='INPUT')return false;"
-               "var type=((el.type||'text')+'').toLowerCase();"
-               "switch(type){"
-               "case '':case 'text':case 'search':case 'url':case 'tel':case 'password':case 'email':case 'number':"
-               "return true;"
-               "default:return false;"
-               "}"
-               "}"
-               "function notify(element){"
-               "var focused=isTextInputElement(element)?'1':'0';"
-               "if(typeof window['" + callbackName + "']==='function'){window['" + callbackName + "'](focused);}"
-               "}"
-               "window.__prismaImeFocusNotify=notify;"
-               "window.__prismaImeFocusTrackingInstalled=true;"
-               "document.addEventListener('focusin',function(event){notify(event.target);},true);"
-               "document.addEventListener('focusout',function(){setTimeout(function(){notify(document.activeElement);},0);},true);"
-               "notify(document.activeElement);"
-               "})();";
-    }
-
-    void InstallImeFocusTrackingForView(const Core::PrismaViewId& viewId) {
-        if (!g_ultralightThreadExecutor || !g_viewsMap || !g_viewsMapMutex || viewId == 0) {
-            return;
-        }
-
-        auto install = [viewId]() {
-            std::shared_ptr<Core::PrismaView> viewData = nullptr;
-            {
-                std::shared_lock lock(*g_viewsMapMutex);
-                auto it = g_viewsMap->find(viewId);
-                if (it != g_viewsMap->end()) {
-                    viewData = it->second;
-                }
-            }
-
-            if (!viewData || !viewData->ultralightView || !viewData->isLoadingFinished.load()) {
-                return;
-            }
-
-            Communication::BindJSCallbacks(viewId);
-
-            try {
-                ultralight::String script = BuildImeFocusTrackingScript().c_str();
-                viewData->ultralightView->EvaluateScript(script, nullptr, "");
-            } catch (const std::exception& e) {
-                logger::error("Failed to install IME focus tracking for View [{}]: {}", viewId, e.what());
-            } catch (...) {
-                logger::error("Failed to install IME focus tracking for View [{}]: unknown exception", viewId);
-            }
-        };
-
-        if (g_ultralightThreadExecutor->IsWorkerThread()) {
-            install();
-            return;
-        }
-
-        g_ultralightThreadExecutor->submit(install);
-    }
 
     // Clipboard helper functions
     std::string EscapeForJS(const std::string& text) {
@@ -390,6 +318,11 @@ namespace PrismaUI::InputHandler {
                 return RE::BSEventNotifyControl::kContinue;
             }
 
+            // In VR, PrismaVR laser input owns pointer and scroll events.
+            if (PrismaVR::IsVRActive()) {
+                return RE::BSEventNotifyControl::kContinue;
+            }
+
             auto cursor = RE::MenuCursor::GetSingleton();
             if (!cursor) {
                 return RE::BSEventNotifyControl::kContinue;
@@ -508,6 +441,17 @@ namespace PrismaUI::InputHandler {
 
     LRESULT CALLBACK SubclassProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam, UINT_PTR uIdSubclass,
                                   DWORD_PTR /*dwRefData*/) {
+        // In VR, PrismaVR owns keyboard input; leave upstream desktop input handling untouched.
+        if (PrismaVR::IsVRActive()) {
+            if (uMsg == WM_NCDESTROY) {
+                RemoveWindowSubclass(hwnd, SubclassProc, uIdSubclass);
+                if (uIdSubclass == SUBCLASS_ID) {
+                    g_wndProcInstalled.store(false);
+                }
+            }
+            return DefSubclassProc(hwnd, uMsg, wParam, lParam);
+        }
+
         LRESULT imeControlResult = 0;
         if (g_imeHelper.HandleControlMessage(hwnd, uMsg, wParam, lParam, &imeControlResult)) {
             return imeControlResult;
@@ -538,30 +482,27 @@ namespace PrismaUI::InputHandler {
                     case WM_KEYDOWN: {
                         // Handle Ctrl+V (Paste)
                         if ((GetKeyState(VK_CONTROL) & 0x8000) && wParam == 'V') {
-                            const bool viewHasInputFieldFocus = g_isFocusedTextInputActive.load();
-                            if (viewHasInputFieldFocus) {
-                                try {
-                                    std::string clipboardText = GetClipboardText();
-                                    if (!clipboardText.empty()) {
-                                        logger::debug("Ctrl+V: Pasting {} characters from clipboard",
-                                                      clipboardText.length());
+                            try {
+                                std::string clipboardText = GetClipboardText();
+                                if (!clipboardText.empty()) {
+                                    logger::debug("Ctrl+V: Pasting {} characters from clipboard",
+                                                  clipboardText.length());
 
-                                        // Escape text for JavaScript string
-                                        std::string escapedText = EscapeForJS(clipboardText);
+                                    // Escape text for JavaScript string
+                                    std::string escapedText = EscapeForJS(clipboardText);
 
-                                        if (escapedText.empty() && !clipboardText.empty()) {
-                                            logger::warn("Failed to escape clipboard text, paste cancelled");
-                                        } else if (!escapedText.empty()) {
-                                            // Use JavaScript execCommand to insert text properly (handles UTF-8)
-                                            std::string script =
-                                                "document.execCommand('insertText', false, '" + escapedText + "')";
+                                    if (escapedText.empty() && !clipboardText.empty()) {
+                                        logger::warn("Failed to escape clipboard text, paste cancelled");
+                                    } else if (!escapedText.empty()) {
+                                        // Use JavaScript execCommand to insert text properly (handles UTF-8)
+                                        std::string script =
+                                            "document.execCommand('insertText', false, '" + escapedText + "')";
 
-                                            PrismaUI::Communication::Invoke(focusedViewIdCopy, script.c_str());
-                                        }
+                                        PrismaUI::Communication::Invoke(focusedViewIdCopy, script.c_str());
                                     }
-                                } catch (const std::exception& e) {
-                                    logger::error("Exception during paste operation: {}", e.what());
                                 }
+                            } catch (const std::exception& e) {
+                                logger::error("Exception during paste operation: {}", e.what());
                             }
                             handledByUI = true;
                             break;
@@ -635,32 +576,27 @@ namespace PrismaUI::InputHandler {
                         break;
                     }
                     case WM_CHAR: {
-                        const bool viewHasInputFieldFocus = g_isFocusedTextInputActive.load();
-                        if (viewHasInputFieldFocus) {
-                            handledByUI = true;
+                        handledByUI = true;
 
-                            wchar_t ch = static_cast<wchar_t>(wParam);
-                            if (IsHighSurrogate(ch)) {
-                                g_pendingHighSurrogate = ch;
-                                break;
-                            }
+                        wchar_t ch = static_cast<wchar_t>(wParam);
+                        if (IsHighSurrogate(ch)) {
+                            g_pendingHighSurrogate = ch;
+                            break;
+                        }
 
-                            std::wstring committedText;
-                            if (IsLowSurrogate(ch) && g_pendingHighSurrogate != 0) {
-                                committedText.push_back(g_pendingHighSurrogate);
-                                committedText.push_back(ch);
-                                g_pendingHighSurrogate = 0;
-                            } else {
-                                g_pendingHighSurrogate = 0;
-                                if (ShouldQueueChar(ch)) {
-                                    committedText.push_back(ch);
-                                }
-                            }
-
-                            QueueCommittedCharEvent(committedText, lParam);
+                        std::wstring committedText;
+                        if (IsLowSurrogate(ch) && g_pendingHighSurrogate != 0) {
+                            committedText.push_back(g_pendingHighSurrogate);
+                            committedText.push_back(ch);
+                            g_pendingHighSurrogate = 0;
                         } else {
                             g_pendingHighSurrogate = 0;
+                            if (ShouldQueueChar(ch)) {
+                                committedText.push_back(ch);
+                            }
                         }
+
+                        QueueCommittedCharEvent(committedText, lParam);
                         break;
                     }
                     case WM_UNICHAR: {
@@ -668,15 +604,12 @@ namespace PrismaUI::InputHandler {
                             return TRUE;
                         }
 
-                        const bool viewHasInputFieldFocus = g_isFocusedTextInputActive.load();
-                        if (viewHasInputFieldFocus) {
-                            handledByUI = true;
+                        handledByUI = true;
 
-                            std::wstring committedText = ConvertCodePointToUtf16(static_cast<UINT>(wParam));
-                            if (!committedText.empty() && ShouldQueueChar(committedText[0])) {
-                                g_pendingHighSurrogate = 0;
-                                QueueCommittedCharEvent(committedText, lParam);
-                            }
+                        std::wstring committedText = ConvertCodePointToUtf16(static_cast<UINT>(wParam));
+                        if (!committedText.empty() && ShouldQueueChar(committedText[0])) {
+                            g_pendingHighSurrogate = 0;
+                            QueueCommittedCharEvent(committedText, lParam);
                         }
                         break;
                     }
@@ -711,7 +644,6 @@ namespace PrismaUI::InputHandler {
         g_viewsMap = viewsMap;
         g_viewsMapMutex = viewsMapMutex;
         g_isAnyInputCaptureActive = false;
-        g_isFocusedTextInputActive = false;
         {
             std::lock_guard lock(g_focusedViewIdMutex);
             g_currentlyFocusedViewId = 0;
@@ -725,8 +657,7 @@ namespace PrismaUI::InputHandler {
             [](const std::string& s) { return EscapeForJS(s); },
             [](const std::wstring& ws, LPARAM lp) { QueueCommittedCharEvent(ws, lp); },
             [](const wchar_t* p, int len) { return ConvertUtf16ToUtf8(p, len); });
-        g_imeHelper.SetContext({g_hWnd, g_viewsMap, g_viewsMapMutex, &g_focusedViewIdMutex,
-                                &g_currentlyFocusedViewId, &g_isAnyInputCaptureActive, &g_isFocusedTextInputActive});
+        g_imeHelper.SetContext({g_hWnd, g_viewsMap, g_viewsMapMutex});
         g_imeHelper.SetExecutor(g_ultralightThreadExecutor);
         g_imeHelper.Initialize(g_hWnd);
 
@@ -737,6 +668,8 @@ namespace PrismaUI::InputHandler {
         } else {
             logger::error("Failed to register MouseEventListener: BSInputDeviceManager is null");
         }
+
+        GamepadInputHandler::Initialize(g_ultralightThreadExecutor);
     }
 
     bool InstallWndProcHook() {
@@ -792,7 +725,6 @@ namespace PrismaUI::InputHandler {
             logger::warn("EnableInputCapture called with empty viewId.");
             return;
         }
-        bool firstTimeActivation = false;
         {
             std::lock_guard lock(g_focusedViewIdMutex);
             if (g_currentlyFocusedViewId != viewId) {
@@ -802,40 +734,15 @@ namespace PrismaUI::InputHandler {
         }
 
         if (!g_isAnyInputCaptureActive.exchange(true)) {
-            firstTimeActivation = true;
             logger::debug("PrismaUI Input Capture System Enabled for View [{}].", viewId);
         }
 
-        g_isFocusedTextInputActive.store(false);
-        g_imeHelper.SetAssociation(false);
-
-        Communication::RegisterJSListener(viewId, IME_FOCUS_CALLBACK_NAME, [viewId](std::string focused) {
-            Core::PrismaViewId currentFocusedViewId = 0;
-            {
-                std::lock_guard lock(g_focusedViewIdMutex);
-                currentFocusedViewId = g_currentlyFocusedViewId;
-            }
-
-            if (currentFocusedViewId != viewId) {
-                return;
-            }
-
-            const bool isTextInputFocused = focused == "1";
-            const bool isCaptureActive = g_isAnyInputCaptureActive.load();
-            g_isFocusedTextInputActive.store(isTextInputFocused);
-            g_imeHelper.SetAssociation(isCaptureActive && isTextInputFocused);
-
-            if (!isTextInputFocused && g_ultralightThreadExecutor) {
-                g_ultralightThreadExecutor->submit([viewId]() {
-                    g_imeHelper.ClearStateInJS(viewId);
-                });
-            } else if (!isTextInputFocused) {
-                g_imeHelper.ClearStateInJS(viewId);
-            }
-        });
-        InstallImeFocusTrackingForView(viewId);
+        g_imeHelper.SetAssociation(true);
 
         g_mouseButtonStates[0] = g_mouseButtonStates[1] = g_mouseButtonStates[2] = false;
+
+        //A view just gained focus. Clear stale button values so a held button re-fires on its next press:
+        GamepadInputHandler::ResetButtonValues();
     }
 
     void DisableInputCapture(const Core::PrismaViewId& viewIdToUnfocus) {
@@ -854,12 +761,14 @@ namespace PrismaUI::InputHandler {
 
         if (disableSystem) {
             if (g_isAnyInputCaptureActive.exchange(false)) {
-                g_isFocusedTextInputActive.store(false);
                 g_imeHelper.SetAssociation(false);
                 logger::debug("PrismaUI Input Capture System Disabled (was active for View [{}]).",
                               currentFocusedBeforeDisable);
 
                 g_mouseButtonStates[0] = g_mouseButtonStates[1] = g_mouseButtonStates[2] = false;
+
+                //Focus released. Reset button values so it doesn't leak into the next focused view.
+                GamepadInputHandler::ResetButtonValues();
 
                 if (g_ultralightThreadExecutor && currentFocusedBeforeDisable != 0) {
                     g_ultralightThreadExecutor->submit([viewId_copy = currentFocusedBeforeDisable]() {
@@ -898,12 +807,16 @@ namespace PrismaUI::InputHandler {
             return;
         }
 
-        g_isFocusedTextInputActive.store(false);
         g_imeHelper.SetAssociation(false);
         g_imeHelper.ClearStateInJS(viewId);
     }
 
     bool IsAnyInputCaptureActive() { return g_isAnyInputCaptureActive.load(); }
+
+    Core::PrismaViewId GetFocusedViewId() {
+        std::lock_guard lock(g_focusedViewIdMutex);
+        return g_currentlyFocusedViewId;
+    }
 
     bool IsInputCaptureActiveForView(const Core::PrismaViewId& viewId) {
         Core::PrismaViewId currentFocused;
@@ -917,6 +830,8 @@ namespace PrismaUI::InputHandler {
 
     void ProcessEvents() {
         if (!g_ultralightThreadExecutor || !g_viewsMap || !g_viewsMapMutex) return;
+
+        GamepadInputHandler::ProcessEvents();
 
         Core::PrismaViewId focusedViewIdCopy;
         {
@@ -1039,6 +954,8 @@ namespace PrismaUI::InputHandler {
             logger::debug("MouseEventListener removed from BSInputDeviceManager");
         }
 
+        GamepadInputHandler::Shutdown();
+
         UninstallWndProcHook();
 
         g_imeHelper.Shutdown(g_hWnd);
@@ -1047,7 +964,6 @@ namespace PrismaUI::InputHandler {
         g_ultralightThreadExecutor = nullptr;
         g_viewsMap = nullptr;
         g_viewsMapMutex = nullptr;
-        g_isFocusedTextInputActive = false;
         logger::info("PrismaUI::InputHandler Shutdown.");
     }
 }

--- a/src/PrismaUI/InputHandler.h
+++ b/src/PrismaUI/InputHandler.h
@@ -43,6 +43,9 @@ namespace PrismaUI::InputHandler {
 
     bool IsAnyInputCaptureActive();
 
+    // The currently focused view ID (0 if none)
+    Core::PrismaViewId GetFocusedViewId();
+
     bool InstallWndProcHook();
     void UninstallWndProcHook();
 


### PR DESCRIPTION
This adds gamepad support both by enabling the use of `navigator.getGamepads()` and two new `CustomEvent`s on window: "prismagamepadbuttondown" and "prismagamepadbuttonup." These `CustomEvent`s have a `detail` object like this:
`detail: { w3cButtonIndex: number, skyrimIdCode: number, action: string }`
The `action` string is especially useful for menus. It will indicate "accept" or "cancel" depending on the user's controller configuration.