### PR TITLE
feat: add gamepad support

### DIFF
--- a/src/PrismaUI/Communication.cpp
+++ b/src/PrismaUI/Communication.cpp
@@ -43,6 +43,25 @@ namespace PrismaUI::Communication {
         });
     }
 
+    void InvokeFromUltralightThread(const Core::PrismaViewId& viewId, const String& script) {
+        std::shared_ptr<PrismaView> viewData = nullptr;
+        {
+            std::shared_lock lock(viewsMutex);
+            auto it = views.find(viewId);
+            if (it != views.end()) {
+                viewData = it->second;
+            }
+        }
+
+        if (!viewData || !viewData->ultralightView) {
+            logger::error("InvokeFromUltralightThread: View ID [{}] not found.", viewId);
+            return;
+        }
+
+        // Already on the Ultralight thread, so evaluate inline rather than submitting another task.
+        viewData->ultralightView->EvaluateScript(script, nullptr, "");
+    }
+
     void RegisterJSListener(const Core::PrismaViewId& viewId, const std::string& name,
                             Core::SimpleJSCallback callback) {
         if (!ViewManager::IsValid(viewId)) {

--- a/src/PrismaUI/Communication.h
+++ b/src/PrismaUI/Communication.h
@@ -17,6 +17,9 @@ namespace PrismaUI::Core {
 namespace PrismaUI::Communication {
     void Invoke(const Core::PrismaViewId& viewId, const ultralight::String& script,
                 std::function<void(std::string)> callback = nullptr);
+    // Call only from Ultralight threads. Otherwise, use Invoke.
+    // This is a synchronous variant of Invoke.
+    void InvokeFromUltralightThread(const Core::PrismaViewId& viewId, const ultralight::String& script);
     void BindJSCallbacks(const Core::PrismaViewId& viewId);
     JSValueRef InvokeCppCallback(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount,
                                  const JSValueRef arguments[], JSValueRef* exception);

--- a/src/PrismaUI/GamepadInputHandler.cpp
+++ b/src/PrismaUI/GamepadInputHandler.cpp
@@ -1,0 +1,312 @@
+#include "GamepadInputHandler.h"
+
+// Ultralight headers trip C4100 (unreferenced formal parameter); silence it for them only.
+#pragma warning(push)
+#pragma warning(disable : 4100)
+#include <Ultralight/Ultralight.h>
+#pragma warning(pop)
+
+#include <atomic>
+#include <mutex>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "Communication.h"
+#include "Core.h"
+#include "InputHandler.h"
+#include "PrismaVR.h"
+#include "Utils/SingleThreadExecutor.h"
+
+// Gamepad Support: Ultralight will not automatically detect a gamepad.
+// This code uses BSInputDeviceManager to monitor button presses.
+// It informs Ultralight via Renderer::FireGamepad* so navigator.getGamepads() can function normally.
+// The controller is always at index 0 and mimicks the standard W3C controller:
+// https://www.w3.org/TR/gamepad/#remapping
+//
+// Threading: input is captured and queued on the game's input thread; the queue is drained and
+// fired on the Renderer from the Ultralight thread, because Renderer calls are single-threaded.
+namespace PrismaUI::GamepadInputHandler {
+    namespace {
+        constexpr uint32_t GAMEPAD_INDEX = 0;          // The gamepad is always depicted at index 0.
+        constexpr uint32_t GAMEPAD_AXIS_COUNT = 4;     // W3C standard gamepad with left and right X and Y axes
+        constexpr uint32_t GAMEPAD_BUTTON_COUNT = 17;  // W3C standard gamepad with 17 buttons
+
+        // A queued gamepad event: a button change or an axis change.
+        using GamepadQueuedEvent = std::variant<ultralight::GamepadButtonEvent, ultralight::GamepadAxisEvent>;
+        std::mutex g_gamepadQueueMutex;  // Guards g_gamepadQueue across the input and Ultralight threads
+        std::vector<GamepadQueuedEvent>
+            g_gamepadQueue;  // Input thread adds to this vector. Ultralight thread consumes.
+
+        // Allows execution on the Ultralight thread. Calls Core::Renderer. Owned by InputHandler.
+        SingleThreadExecutor* g_ultralightThreadExecutor = nullptr;
+        // Ensure virtual gamepad is declared to the Renderer once upon the first input.
+        std::atomic<bool> g_gamepadRegistered = false;
+        float g_gamepadButtonValues[GAMEPAD_BUTTON_COUNT] = {};  // Last observed value per button.
+
+        // Converts Skyrim ID Code to W3C index (-1 if not recognized, e.g., guide button)
+        int SkyrimIDCodeToW3CIndex(uint32_t skyrimCode) {
+            using Key = RE::BSWin32GamepadDevice::Key;
+            return skyrimCode == Key::kA               ? 0
+                   : skyrimCode == Key::kB             ? 1
+                   : skyrimCode == Key::kX             ? 2
+                   : skyrimCode == Key::kY             ? 3
+                   : skyrimCode == Key::kLeftShoulder  ? 4
+                   : skyrimCode == Key::kRightShoulder ? 5
+                   : skyrimCode == Key::kLeftTrigger   ? 6  // analog
+                   : skyrimCode == Key::kRightTrigger  ? 7  // analog
+                   : skyrimCode == Key::kBack          ? 8
+                   : skyrimCode == Key::kStart         ? 9
+                   : skyrimCode == Key::kLeftThumb     ? 10
+                   : skyrimCode == Key::kRightThumb    ? 11
+                   : skyrimCode == Key::kUp            ? 12
+                   : skyrimCode == Key::kDown          ? 13
+                   : skyrimCode == Key::kLeft          ? 14
+                   : skyrimCode == Key::kRight         ? 15
+                                                       : -1;
+        }
+
+        // Resolves the menu role of the button via the control map and dispatches a named CustomEvent
+        // (detail: { w3cButtonIndex: number, skyrimIdCode: number, action: string }) to the focused view.
+        // These events are dispatched on window.
+        // eventName is "prismagamepadbuttondown" on a press or "prismagamepadbuttonup" on a release.
+        void DispatchButtonEvent(const char* eventName, uint32_t w3cButtonIndex, uint32_t skyrimIDCode) {
+            const Core::PrismaViewId viewId = InputHandler::GetFocusedViewId();
+            if (viewId == 0) {
+                return;
+            }
+
+            const char* action = "";
+            if (auto* controlMap = RE::ControlMap::GetSingleton()) {
+                using Context = RE::ControlMap::InputContextID;
+                const uint32_t acceptIDCode =
+                    controlMap->GetMappedKey("Accept", RE::INPUT_DEVICE::kGamepad, Context::kMenuMode);
+                if (acceptIDCode == skyrimIDCode) {
+                    action = "accept";
+                } else {
+                    const uint32_t cancelIDCode =
+                        controlMap->GetMappedKey("Cancel", RE::INPUT_DEVICE::kGamepad, Context::kMenuMode);
+                    if (cancelIDCode == skyrimIDCode) {
+                        action = "cancel";
+                    }
+                }
+            }
+
+            const std::string script = std::string("window.dispatchEvent(new CustomEvent(\"") + eventName +
+                                       "\", {detail: {w3cButtonIndex: " + std::to_string(w3cButtonIndex) +
+                                       ", skyrimIdCode: " + std::to_string(skyrimIDCode) + ", action: \"" + action +
+                                       "\"}}))";
+            Communication::Invoke(viewId, script.c_str());
+        }
+
+        // --- Input thread: capture into the queue ---
+
+        // Maps a gamepad button event to the standard layout and queues it, skipping unchanged repeats.
+        void QueueButtonEvent(RE::ButtonEvent* buttonEvent) {
+            const uint32_t buttonIDCode = buttonEvent->GetIDCode();
+            const int w3cButtonIndexInt = SkyrimIDCodeToW3CIndex(buttonIDCode);  // Skyrim code -> W3C index.
+            if (w3cButtonIndexInt < 0) {
+                // Unrecognized input
+                return;
+            }
+
+            const uint32_t w3cButtonIndex = static_cast<uint32_t>(w3cButtonIndexInt);
+
+            // Fire buttondown on the press edge and buttonup on the release edge.
+            if (buttonEvent->IsDown()) {
+                DispatchButtonEvent("prismagamepadbuttondown", w3cButtonIndex, buttonIDCode);
+            } else if (buttonEvent->IsUp()) {
+                DispatchButtonEvent("prismagamepadbuttonup", w3cButtonIndex, buttonIDCode);
+            }
+
+            // A trigger ranges from 0 to 1 (float); a digital button returns 0 or 1.
+            const float value = buttonEvent->Value();
+            if (g_gamepadButtonValues[w3cButtonIndex] == value) {
+                // Button value unchanged since last event. Don't send unnecessarily.
+                return;
+            }
+            // Save button value for future calls to this function.
+            g_gamepadButtonValues[w3cButtonIndex] = value;
+
+            // Build event to be received by the Renderer
+            ultralight::GamepadButtonEvent ev{};
+            ev.index = GAMEPAD_INDEX;
+            ev.button_index = w3cButtonIndex;
+            ev.value = value;
+
+            // Add to gamepad queue so it can be picked up later on the Ultralight thread.
+            std::lock_guard lock(g_gamepadQueueMutex);
+            g_gamepadQueue.emplace_back(ev);
+        }
+
+        // Maps a thumbstick event to its standard axis pair and queues both axes together.
+        void QueueThumbstickEvent(RE::ThumbstickEvent* thumbstickEvent) {
+            // Pick the standard axis pair for whichever stick moved.
+            uint32_t xAxis;
+            uint32_t yAxis;
+            if (thumbstickEvent->IsLeft()) {
+                xAxis = 0;
+                yAxis = 1;
+            } else if (thumbstickEvent->IsRight()) {
+                xAxis = 2;
+                yAxis = 3;
+            } else {
+                // If neither left nor right, ignore.
+                return;
+            }
+
+            // Build x-axis event to be received by the Renderer.
+            ultralight::GamepadAxisEvent xev{};
+            xev.index = GAMEPAD_INDEX;
+            xev.axis_index = xAxis;
+            xev.value = thumbstickEvent->xValue;
+
+            // Build y-axis event to be received by the Renderer.
+            ultralight::GamepadAxisEvent yev{};
+            yev.index = GAMEPAD_INDEX;
+            yev.axis_index = yAxis;
+            // Negate Y: Skyrim reports +up while the W3C standard mapping expects +down.
+            yev.value = -thumbstickEvent->yValue;
+
+            // Add to gamepad queue so it can be picked up later on the Ultralight thread.
+            std::lock_guard lock(g_gamepadQueueMutex);
+            g_gamepadQueue.emplace_back(xev);
+            g_gamepadQueue.emplace_back(yev);
+        }
+
+        // Captures Skyrim gamepad input and queues it for ProcessEvents(). Gated on input capture, like mouse/keyboard.
+        class GamepadEventListener : public RE::BSTEventSink<RE::InputEvent*> {
+        public:
+            static GamepadEventListener* GetSingleton() {
+                // One instance for the process. Its address is used in AddEventSink and RemoveEventSink.
+                static GamepadEventListener singleton;
+                return &singleton;
+            }
+
+            RE::BSEventNotifyControl ProcessEvent(
+                RE::InputEvent* const* a_event,
+                [[maybe_unused]] RE::BSTEventSource<RE::InputEvent*>* a_eventSource) override {
+                // If event is valid, input capture is active, and not VR, queue events.
+                if (a_event && *a_event && InputHandler::IsAnyInputCaptureActive() && !PrismaVR::IsVRActive()) {
+                    for (auto event = *a_event; event; event = event->next) {  // Events arrive as a linked list.
+                        const RE::INPUT_EVENT_TYPE eventType = event->GetEventType();
+                        if (eventType == RE::INPUT_EVENT_TYPE::kButton) {
+                            // For buttons, ensure the device is the gamepad.
+                            auto buttonEvent = event->AsButtonEvent();
+                            if (buttonEvent && buttonEvent->GetDevice() == RE::INPUT_DEVICE::kGamepad) {
+                                QueueButtonEvent(buttonEvent);
+                            }
+                        } else if (eventType == RE::INPUT_EVENT_TYPE::kThumbstick) {
+                            // For thumbsticks, the device is always a gamepad.
+                            if (auto thumbstickEvent = event->AsThumbstickEvent()) {
+                                QueueThumbstickEvent(thumbstickEvent);
+                            }
+                        }
+                    }
+                }
+                return RE::BSEventNotifyControl::kContinue;
+            }
+        };
+
+        // --- Ultralight thread: drain onto the Renderer ---
+
+        // Declares the virtual pad to the Renderer exactly once so navigator.getGamepads() reports it.
+        void EnsureGamepadRegistered() {
+            if (g_gamepadRegistered.exchange(true)) {
+                // If already registered, return.
+                return;
+            }
+            const ultralight::String name = "Skyrim Controller (Standard Mapping)";
+            Core::renderer->SetGamepadDetails(GAMEPAD_INDEX, name, GAMEPAD_AXIS_COUNT, GAMEPAD_BUTTON_COUNT);
+            ultralight::GamepadEvent connectEvent{};
+            connectEvent.type =
+                ultralight::GamepadEvent::kType_GamepadConnected;  // JavaScript "gamepadconnected" event
+            connectEvent.index = GAMEPAD_INDEX;
+            Core::renderer->FireGamepadEvent(connectEvent);
+        }
+
+        // Fires one queued event on the Renderer, picking the call that matches its variant type
+        // This does not trigger any JavaScript event. It just changes gamepad state.
+        void FireGamepadQueuedEvent(const GamepadQueuedEvent& event) {
+            std::visit(
+                [](const auto& arg) {
+                    using T = std::decay_t<decltype(arg)>;
+                    if constexpr (std::is_same_v<T, ultralight::GamepadButtonEvent>) {
+                        Core::renderer->FireGamepadButtonEvent(arg);
+                    } else if constexpr (std::is_same_v<T, ultralight::GamepadAxisEvent>) {
+                        Core::renderer->FireGamepadAxisEvent(arg);
+                    }
+                },
+                event);
+        }
+    }
+
+    void ResetButtonValues() {
+        for (auto& v : g_gamepadButtonValues) {
+            v = 0.0f;
+        }
+    }
+
+    void Initialize(SingleThreadExecutor* ultralightThreadExecutor) {
+        g_ultralightThreadExecutor = ultralightThreadExecutor;
+        g_gamepadRegistered = false;  // Declare the pad to the Renderer on the next input. (The renderer may be new.)
+        ResetButtonValues();          // Start with no inputs pressed
+        {
+            std::lock_guard lock(g_gamepadQueueMutex);
+            g_gamepadQueue.clear();  // Clear any queued events from a previous session.
+        }
+
+        auto inputEventSource = RE::BSInputDeviceManager::GetSingleton();
+        if (inputEventSource) {
+            inputEventSource->AddEventSink(GamepadEventListener::GetSingleton());  // Begin receiving raw input events.
+            logger::info("GamepadEventListener registered with BSInputDeviceManager");
+        } else {
+            logger::error("Failed to register GamepadEventListener: BSInputDeviceManager is null");
+        }
+    }
+
+    // Processes waiting events
+    void ProcessEvents() {
+        if (!g_ultralightThreadExecutor) {
+            return;
+        }
+
+        // Swap the queue out under the lock so it's held only briefly. Then operate on our local copy.
+        std::vector<GamepadQueuedEvent> gamepadEvents;
+        {
+            std::lock_guard lock(g_gamepadQueueMutex);
+            if (g_gamepadQueue.empty()) {
+                // Nothing is queued.
+                return;
+            }
+            // Transfer all queued events to the local queue.
+            gamepadEvents.swap(g_gamepadQueue);
+        }
+
+        // Renderer calls must run on the Ultralight thread, so post the firing there.
+        g_ultralightThreadExecutor->submit([events = std::move(gamepadEvents)]() {
+            if (!Core::renderer) return;  // renderer was torn down between queueing and running.
+            EnsureGamepadRegistered();
+            for (const auto& event : events) {
+                FireGamepadQueuedEvent(event);
+            }
+        });
+    }
+
+    void Shutdown() {
+        auto inputEventSource = RE::BSInputDeviceManager::GetSingleton();
+        if (inputEventSource) {
+            inputEventSource->RemoveEventSink(GamepadEventListener::GetSingleton());  // stop receiving input events.
+            logger::debug("GamepadEventListener removed from BSInputDeviceManager");
+        }
+
+        {
+            std::lock_guard lock(g_gamepadQueueMutex);
+            g_gamepadQueue.clear();  // Clear any unsent events.
+        }
+        g_gamepadRegistered = false;  // Allows a new session to redeclare the gamepad to the new renderer.
+        g_ultralightThreadExecutor = nullptr;
+    }
+}

--- a/src/PrismaUI/GamepadInputHandler.cpp
+++ b/src/PrismaUI/GamepadInputHandler.cpp
@@ -8,6 +8,7 @@
 
 #include <atomic>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -34,8 +35,17 @@ namespace PrismaUI::GamepadInputHandler {
         constexpr uint32_t GAMEPAD_AXIS_COUNT = 4;     // W3C standard gamepad with left and right X and Y axes
         constexpr uint32_t GAMEPAD_BUTTON_COUNT = 17;  // W3C standard gamepad with 17 buttons
 
-        // A queued gamepad event: a button change or an axis change.
-        using GamepadQueuedEvent = std::variant<ultralight::GamepadButtonEvent, ultralight::GamepadAxisEvent>;
+        // A JavaScript event (prismagamepadbuttondown or prismagamepadbuttonup) to dispatch into a view.
+        // It queued right after the button's state change so it runs on the Ultralight thread
+        // only once that state is applied, letting a handler read the new state via navigator.getGamepads().
+        struct JsButtonDispatch {
+            Core::PrismaViewId viewId;
+            std::string script;
+        };
+
+        // A queued gamepad event: a button change, an axis change, or a JS event dispatch.
+        using GamepadQueuedEvent =
+            std::variant<ultralight::GamepadButtonEvent, ultralight::GamepadAxisEvent, JsButtonDispatch>;
         std::mutex g_gamepadQueueMutex;  // Guards g_gamepadQueue across the input and Ultralight threads
         std::vector<GamepadQueuedEvent>
             g_gamepadQueue;  // Input thread adds to this vector. Ultralight thread consumes.
@@ -44,7 +54,13 @@ namespace PrismaUI::GamepadInputHandler {
         SingleThreadExecutor* g_ultralightThreadExecutor = nullptr;
         // Ensure virtual gamepad is declared to the Renderer once upon the first input.
         std::atomic<bool> g_gamepadRegistered = false;
-        float g_gamepadButtonValues[GAMEPAD_BUTTON_COUNT] = {};  // Last observed value per button.
+        // Identifies the current Initialize -> Shutdown session. Incremented in both of those functions.
+        // See use in ProcessEvents.
+        std::atomic<uint64_t> g_session = 0;
+        // Last observed value per button. Atomic because the input thread reads and writes to it
+        // while a focus change (off-thread) may reset it.
+        // std::memory_order_relaxed is used to prevent a torn read, no ordering needed.
+        std::atomic<float> g_gamepadButtonValues[GAMEPAD_BUTTON_COUNT] = {};
 
         // Converts Skyrim ID Code to W3C index (-1 if not recognized, e.g., guide button)
         int SkyrimIDCodeToW3CIndex(uint32_t skyrimCode) {
@@ -68,14 +84,16 @@ namespace PrismaUI::GamepadInputHandler {
                                                        : -1;
         }
 
-        // Resolves the menu role of the button via the control map and dispatches a named CustomEvent
-        // (detail: { w3cButtonIndex: number, skyrimIdCode: number, action: string }) to the focused view.
-        // These events are dispatched on window.
+        // Resolves the menu role of the button via the control map and builds a named CustomEvent
+        // (detail: { w3cButtonIndex: number, skyrimIdCode: number, action: string }) dispatched on window.
         // eventName is "prismagamepadbuttondown" on a press or "prismagamepadbuttonup" on a release.
-        void DispatchButtonEvent(const char* eventName, uint32_t w3cButtonIndex, uint32_t skyrimIDCode) {
+        // Returns nullopt when no view is focused. The caller queues the result behind the button's state
+        // change so the event fires only after navigator.getGamepads() reflects it.
+        std::optional<JsButtonDispatch> BuildButtonDispatch(const char* eventName, uint32_t w3cButtonIndex,
+                                                            uint32_t skyrimIDCode) {
             const Core::PrismaViewId viewId = InputHandler::GetFocusedViewId();
             if (viewId == 0) {
-                return;
+                return std::nullopt;
             }
 
             const char* action = "";
@@ -94,11 +112,11 @@ namespace PrismaUI::GamepadInputHandler {
                 }
             }
 
-            const std::string script = std::string("window.dispatchEvent(new CustomEvent(\"") + eventName +
-                                       "\", {detail: {w3cButtonIndex: " + std::to_string(w3cButtonIndex) +
-                                       ", skyrimIdCode: " + std::to_string(skyrimIDCode) + ", action: \"" + action +
-                                       "\"}}))";
-            Communication::Invoke(viewId, script.c_str());
+            std::string script = std::string("window.dispatchEvent(new CustomEvent(\"") + eventName +
+                                 "\", {detail: {w3cButtonIndex: " + std::to_string(w3cButtonIndex) +
+                                 ", skyrimIdCode: " + std::to_string(skyrimIDCode) + ", action: \"" + action +
+                                 "\"}}))";
+            return JsButtonDispatch{viewId, std::move(script)};
         }
 
         // --- Input thread: capture into the queue ---
@@ -114,31 +132,38 @@ namespace PrismaUI::GamepadInputHandler {
 
             const uint32_t w3cButtonIndex = static_cast<uint32_t>(w3cButtonIndexInt);
 
-            // Fire buttondown on the press edge and buttonup on the release edge.
+            // Build the buttondown/up dispatch (if any) before taking the queue lock.
+            // It reads the focused view and control map,
+            // which we don't want to do while holding g_gamepadQueueMutex.
+            std::optional<JsButtonDispatch> dispatch;
             if (buttonEvent->IsDown()) {
-                DispatchButtonEvent("prismagamepadbuttondown", w3cButtonIndex, buttonIDCode);
+                dispatch = BuildButtonDispatch("prismagamepadbuttondown", w3cButtonIndex, buttonIDCode);
             } else if (buttonEvent->IsUp()) {
-                DispatchButtonEvent("prismagamepadbuttonup", w3cButtonIndex, buttonIDCode);
+                dispatch = BuildButtonDispatch("prismagamepadbuttonup", w3cButtonIndex, buttonIDCode);
             }
 
             // A trigger ranges from 0 to 1 (float); a digital button returns 0 or 1.
             const float value = buttonEvent->Value();
-            if (g_gamepadButtonValues[w3cButtonIndex] == value) {
-                // Button value unchanged since last event. Don't send unnecessarily.
-                return;
+            const float oldValue = g_gamepadButtonValues[w3cButtonIndex].load(std::memory_order_relaxed);
+            const bool valueChanged = oldValue != value;
+            if (valueChanged) {
+                // Save button value for future calls to this function.
+                g_gamepadButtonValues[w3cButtonIndex].store(value, std::memory_order_relaxed);
             }
-            // Save button value for future calls to this function.
-            g_gamepadButtonValues[w3cButtonIndex] = value;
 
-            // Build event to be received by the Renderer
-            ultralight::GamepadButtonEvent ev{};
-            ev.index = GAMEPAD_INDEX;
-            ev.button_index = w3cButtonIndex;
-            ev.value = value;
-
-            // Add to gamepad queue so it can be picked up later on the Ultralight thread.
+            // Queue the state change first, then the JS dispatch, so the event fires (on the Ultralight
+            // thread) only after the Renderer state is applied. A handler can then read it via getGamepads().
             std::lock_guard lock(g_gamepadQueueMutex);
-            g_gamepadQueue.emplace_back(ev);
+            if (valueChanged) {
+                ultralight::GamepadButtonEvent ev{};
+                ev.index = GAMEPAD_INDEX;
+                ev.button_index = w3cButtonIndex;
+                ev.value = value;
+                g_gamepadQueue.emplace_back(ev);
+            }
+            if (dispatch) {
+                g_gamepadQueue.emplace_back(std::move(*dispatch));
+            }
         }
 
         // Maps a thumbstick event to its standard axis pair and queues both axes together.
@@ -174,6 +199,30 @@ namespace PrismaUI::GamepadInputHandler {
             std::lock_guard lock(g_gamepadQueueMutex);
             g_gamepadQueue.emplace_back(xev);
             g_gamepadQueue.emplace_back(yev);
+        }
+
+        // Queues a zeroed event for every button and axis so the Renderer's virtual pad reads neutral.
+        // The input sink is gated on focus (see ProcessEvent), so a release or recenter that happens while
+        // unfocused is dropped.
+        // A common example is the Cancel button held to close a view and then released after blur.
+        // Without this, navigator.getGamepads() would stay latched with that press and the next focused
+        // view would inherit the stale state. Called on focus loss from ResetButtonValues.
+        void QueueNeutralizeAll() {
+            std::lock_guard lock(g_gamepadQueueMutex);
+            for (uint32_t buttonIndex = 0; buttonIndex < GAMEPAD_BUTTON_COUNT; ++buttonIndex) {
+                ultralight::GamepadButtonEvent ev{};
+                ev.index = GAMEPAD_INDEX;
+                ev.button_index = buttonIndex;
+                ev.value = 0.0f;
+                g_gamepadQueue.emplace_back(ev);
+            }
+            for (uint32_t axisIndex = 0; axisIndex < GAMEPAD_AXIS_COUNT; ++axisIndex) {
+                ultralight::GamepadAxisEvent ev{};
+                ev.index = GAMEPAD_INDEX;
+                ev.axis_index = axisIndex;
+                ev.value = 0.0f;
+                g_gamepadQueue.emplace_back(ev);
+            }
         }
 
         // Captures Skyrim gamepad input and queues it for ProcessEvents(). Gated on input capture, like mouse/keyboard.
@@ -227,8 +276,9 @@ namespace PrismaUI::GamepadInputHandler {
             Core::renderer->FireGamepadEvent(connectEvent);
         }
 
-        // Fires one queued event on the Renderer, picking the call that matches its variant type
-        // This does not trigger any JavaScript event. It just changes gamepad state.
+        // Applies one queued event on the Ultralight thread. Button and axis changes update the Renderer's
+        // gamepad state (no JavaScript event). A JsButtonDispatch runs the buttondown/up CustomEvent in the
+        // view. Because a dispatch is queued after its state change, getGamepads() is current when it fires.
         void FireGamepadQueuedEvent(const GamepadQueuedEvent& event) {
             std::visit(
                 [](const auto& arg) {
@@ -237,6 +287,11 @@ namespace PrismaUI::GamepadInputHandler {
                         Core::renderer->FireGamepadButtonEvent(arg);
                     } else if constexpr (std::is_same_v<T, ultralight::GamepadAxisEvent>) {
                         Core::renderer->FireGamepadAxisEvent(arg);
+                    } else if constexpr (std::is_same_v<T, JsButtonDispatch>) {
+                        // Communication::Invoke(arg.viewId, arg.script.c_str());
+                        // We're already on the Ultralight thread, and the button's state event was fired just above,
+                        // so getGamepads() is current inside the handler.
+                        Communication::InvokeFromUltralightThread(arg.viewId, arg.script.c_str());
                     }
                 },
                 event);
@@ -244,12 +299,20 @@ namespace PrismaUI::GamepadInputHandler {
     }
 
     void ResetButtonValues() {
+        // Clear the local edge-detection cache so a still-held button re-fires as a fresh 0 -> 1 change.
         for (auto& v : g_gamepadButtonValues) {
-            v = 0.0f;
+            v.store(0.0f, std::memory_order_relaxed);
+        }
+        // Neutralize the Renderer's pad on focus loss only (no view focused). Capture is already disabled
+        // by then, so nothing races the zero batch. Doing it on focus gain instead could clobber a
+        // concurrent press and would be redundant since the preceding loss already cleared the pad.
+        if (InputHandler::GetFocusedViewId() == 0) {
+            QueueNeutralizeAll();
         }
     }
 
     void Initialize(SingleThreadExecutor* ultralightThreadExecutor) {
+        ++g_session;  // New session: invalidate any batch still queued from a prior one.
         g_ultralightThreadExecutor = ultralightThreadExecutor;
         g_gamepadRegistered = false;  // Declare the pad to the Renderer on the next input. (The renderer may be new.)
         ResetButtonValues();          // Start with no inputs pressed
@@ -286,8 +349,13 @@ namespace PrismaUI::GamepadInputHandler {
         }
 
         // Renderer calls must run on the Ultralight thread, so post the firing there.
-        g_ultralightThreadExecutor->submit([events = std::move(gamepadEvents)]() {
-            if (!Core::renderer) return;  // renderer was torn down between queueing and running.
+        // Save the current session so it can be checked within g_ultralightThreadExecutor->submit.
+        const uint64_t session = g_session.load();
+        g_ultralightThreadExecutor->submit([events = std::move(gamepadEvents), session]() {
+            if (!Core::renderer || session != g_session.load()) {
+                // If renderer was torn down or session changed, stop.
+                return;
+            }
             EnsureGamepadRegistered();
             for (const auto& event : events) {
                 FireGamepadQueuedEvent(event);
@@ -296,6 +364,7 @@ namespace PrismaUI::GamepadInputHandler {
     }
 
     void Shutdown() {
+        ++g_session;  // Session ending: any batch still queued from it must now be dropped.
         auto inputEventSource = RE::BSInputDeviceManager::GetSingleton();
         if (inputEventSource) {
             inputEventSource->RemoveEventSink(GamepadEventListener::GetSingleton());  // stop receiving input events.

--- a/src/PrismaUI/GamepadInputHandler.h
+++ b/src/PrismaUI/GamepadInputHandler.h
@@ -1,0 +1,20 @@
+#pragma once
+
+class SingleThreadExecutor;
+
+namespace PrismaUI::GamepadInputHandler {
+    // Registers the gamepad input sink with BSInputDeviceManager and stores the Ultralight thread
+    // executor used to fire events on the Renderer. Call once from InputHandler::Initialize.
+    void Initialize(SingleThreadExecutor* ultralightThreadExecutor);
+
+    // Drains queued gamepad events and fires them on the Renderer.
+    // Call from InputHandler::ProcessEvents.
+    void ProcessEvents();
+
+    // Reset all "held" buttons so the next press registers as a fresh 0 -> 1 change. This function is called on
+    // initialization and focus changes.
+    void ResetButtonValues();
+
+    // Removes the sink and clears queued state.
+    void Shutdown();
+}

--- a/src/PrismaUI/GamepadInputHandler.h
+++ b/src/PrismaUI/GamepadInputHandler.h
@@ -11,8 +11,11 @@ namespace PrismaUI::GamepadInputHandler {
     // Call from InputHandler::ProcessEvents.
     void ProcessEvents();
 
-    // Reset all "held" buttons so the next press registers as a fresh 0 -> 1 change. This function is called on
-    // initialization and focus changes.
+    // Reset all "held" buttons so the next press registers as a fresh 0 -> 1 change.
+    // Call on initialization and focus changes.
+    // On focus loss it also pushes a neutral state to the Renderer so no button or axis stays latched
+    // into the next focused view. (The input sink is gated on focus, so a release that lands while
+    // unfocused would otherwise leave navigator.getGamepads() latched.) 
     void ResetButtonValues();
 
     // Removes the sink and clears queued state.

--- a/src/PrismaUI/InputHandler.cpp
+++ b/src/PrismaUI/InputHandler.cpp
@@ -4,6 +4,7 @@
 
 #include "Communication.h"
 #include "Core.h"
+#include "GamepadInputHandler.h"
 #include "ImeHelper.h"
 #include "PrismaVR.h"
 #include "Utils/Encoding.h"
@@ -667,6 +668,8 @@ namespace PrismaUI::InputHandler {
         } else {
             logger::error("Failed to register MouseEventListener: BSInputDeviceManager is null");
         }
+
+        GamepadInputHandler::Initialize(g_ultralightThreadExecutor);
     }
 
     bool InstallWndProcHook() {
@@ -737,6 +740,9 @@ namespace PrismaUI::InputHandler {
         g_imeHelper.SetAssociation(true);
 
         g_mouseButtonStates[0] = g_mouseButtonStates[1] = g_mouseButtonStates[2] = false;
+
+        //A view just gained focus. Clear stale button values so a held button re-fires on its next press:
+        GamepadInputHandler::ResetButtonValues();
     }
 
     void DisableInputCapture(const Core::PrismaViewId& viewIdToUnfocus) {
@@ -760,6 +766,9 @@ namespace PrismaUI::InputHandler {
                               currentFocusedBeforeDisable);
 
                 g_mouseButtonStates[0] = g_mouseButtonStates[1] = g_mouseButtonStates[2] = false;
+
+                //Focus released. Reset button values so it doesn't leak into the next focused view.
+                GamepadInputHandler::ResetButtonValues();
 
                 if (g_ultralightThreadExecutor && currentFocusedBeforeDisable != 0) {
                     g_ultralightThreadExecutor->submit([viewId_copy = currentFocusedBeforeDisable]() {
@@ -804,6 +813,11 @@ namespace PrismaUI::InputHandler {
 
     bool IsAnyInputCaptureActive() { return g_isAnyInputCaptureActive.load(); }
 
+    Core::PrismaViewId GetFocusedViewId() {
+        std::lock_guard lock(g_focusedViewIdMutex);
+        return g_currentlyFocusedViewId;
+    }
+
     bool IsInputCaptureActiveForView(const Core::PrismaViewId& viewId) {
         Core::PrismaViewId currentFocused;
         {
@@ -816,6 +830,8 @@ namespace PrismaUI::InputHandler {
 
     void ProcessEvents() {
         if (!g_ultralightThreadExecutor || !g_viewsMap || !g_viewsMapMutex) return;
+
+        GamepadInputHandler::ProcessEvents();
 
         Core::PrismaViewId focusedViewIdCopy;
         {
@@ -937,6 +953,8 @@ namespace PrismaUI::InputHandler {
             inputEventSource->RemoveEventSink(MouseEventListener::GetSingleton());
             logger::debug("MouseEventListener removed from BSInputDeviceManager");
         }
+
+        GamepadInputHandler::Shutdown();
 
         UninstallWndProcHook();
 

--- a/src/PrismaUI/InputHandler.h
+++ b/src/PrismaUI/InputHandler.h
@@ -43,6 +43,9 @@ namespace PrismaUI::InputHandler {
 
     bool IsAnyInputCaptureActive();
 
+    // The currently focused view ID (0 if none)
+    Core::PrismaViewId GetFocusedViewId();
+
     bool InstallWndProcHook();
     void UninstallWndProcHook();
 

--- a/src/PrismaUI/ViewManager.cpp
+++ b/src/PrismaUI/ViewManager.cpp
@@ -101,6 +101,8 @@ namespace PrismaUI::ViewManager {
             controlMap->ToggleControls(RE::UserEvents::USER_EVENT_FLAG::kActivate, true, false);
             controlMap->ToggleControls(RE::UserEvents::USER_EVENT_FLAG::kPOVSwitch, true, false);
             controlMap->ToggleControls(RE::UserEvents::USER_EVENT_FLAG::kVATS, true, false);
+            // Added for gamepads:
+            controlMap->ToggleControls(RE::UserEvents::USER_EVENT_FLAG::kFighting, true, false);
         }
     }
 
@@ -260,6 +262,8 @@ namespace PrismaUI::ViewManager {
                 controlMap->ToggleControls(RE::UserEvents::USER_EVENT_FLAG::kActivate, false, false);
                 controlMap->ToggleControls(RE::UserEvents::USER_EVENT_FLAG::kPOVSwitch, false, false);
                 controlMap->ToggleControls(RE::UserEvents::USER_EVENT_FLAG::kVATS, false, false);
+                // Added for gamepads:
+                controlMap->ToggleControls(RE::UserEvents::USER_EVENT_FLAG::kFighting, false, false);
             }
 
             if (pauseGame && !PrismaVR::IsVRActive()) {


### PR DESCRIPTION
This pull request adds gamepad support both by enabling the use of `navigator.getGamepads()` and two new `CustomEvent`s on `window`: "prismagamepadbuttondown" and "prismagamepadbuttonup." These `CustomEvent`s have a `detail` object like this:
`detail: { w3cButtonIndex: number, skyrimIdCode: number, action: string }`
The `action` string is especially useful for menus. It will indicate "accept" or "cancel" depending on the user's controller configuration.
(Please excuse the diff of InputHandler.cpp. I'm not sure why GitHub thinks there are differences except for possibly a different in line endings. I only intentionally made seven changes in InputHandler.cpp.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added gamepad support for controller input, including button presses, thumbsticks, and standardized gamepad state reporting.
  * Enabled controller actions to trigger in-app custom events for mapped confirm/cancel behavior.
  * Exposed the currently focused view ID for use across the input flow.

* **Bug Fixes**
  * Improved input state handling by resetting held-button values when focus or input capture changes.
  * Ensured gamepad events are processed and cleared safely across threads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->