### PR TITLE
Fix random VR panel freezes: run ControlMap::ToggleControls on the game thread

### DIFF
--- a/src/PrismaUI/PrismaVR_Bridge.h
+++ b/src/PrismaUI/PrismaVR_Bridge.h
@@ -104,29 +104,35 @@ namespace PrismaVR_Bridge {
 
 	// --- Game control masking (split: combat vs movement) ---
 	// Works on both OpenComposite and SteamVR via Skyrim's ControlMap.
+	//
+	// ToggleControls mutates the game's live input state and is NOT safe from the
+	// render thread (PrismaVR::OnFrame) — it races the game thread's input
+	// processing. All toggles are queued through the SKSE task interface so they
+	// execute on the game thread; AddTask preserves FIFO order, so rapid
+	// mask/unmask sequences from laser clicks apply in the order they were issued.
+
+	inline void ToggleControlsOnGameThread(RE::UserEvents::USER_EVENT_FLAG flag, bool enable) {
+		SKSE::GetTaskInterface()->AddTask([flag, enable]() {
+			auto controlMap = RE::ControlMap::GetSingleton();
+			if (!controlMap) return;
+			controlMap->ToggleControls(flag, enable, false);
+		});
+	}
 
 	inline void MaskCombatControls() {
-		auto controlMap = RE::ControlMap::GetSingleton();
-		if (!controlMap) return;
-		controlMap->ToggleControls(RE::UserEvents::USER_EVENT_FLAG::kFighting, false, false);
+		ToggleControlsOnGameThread(RE::UserEvents::USER_EVENT_FLAG::kFighting, false);
 	}
 
 	inline void UnmaskCombatControls() {
-		auto controlMap = RE::ControlMap::GetSingleton();
-		if (!controlMap) return;
-		controlMap->ToggleControls(RE::UserEvents::USER_EVENT_FLAG::kFighting, true, false);
+		ToggleControlsOnGameThread(RE::UserEvents::USER_EVENT_FLAG::kFighting, true);
 	}
 
 	inline void MaskMovement() {
-		auto controlMap = RE::ControlMap::GetSingleton();
-		if (!controlMap) return;
-		controlMap->ToggleControls(RE::UserEvents::USER_EVENT_FLAG::kMovement, false, false);
+		ToggleControlsOnGameThread(RE::UserEvents::USER_EVENT_FLAG::kMovement, false);
 	}
 
 	inline void UnmaskMovement() {
-		auto controlMap = RE::ControlMap::GetSingleton();
-		if (!controlMap) return;
-		controlMap->ToggleControls(RE::UserEvents::USER_EVENT_FLAG::kMovement, true, false);
+		ToggleControlsOnGameThread(RE::UserEvents::USER_EVENT_FLAG::kMovement, true);
 	}
 
 	// --- JavaScript execution (for injecting VR cursor into HTML views) ---


### PR DESCRIPTION
## Problem

Random hard freezes in VR when using the laser/trigger on a Prisma panel. Repro: open a panel (e.g. an AddItemMenu-style view) and work the trigger on it — after a burst of clicks the game hangs. Reproduced by alpha testers across sessions; the hang lands ~0.1s after a control mask/unmask cycle.

## Root cause

`PrismaVR_Bridge`'s control-masking helpers (`MaskCombatControls` / `UnmaskCombatControls` / `MaskMovement` / `UnmaskMovement`) call `RE::ControlMap::ToggleControls()` **directly from the render thread** — they run inside `PrismaVR::OnFrame()`, which is driven from `D3DPresent`. Every laser trigger press/release mutates the game's live input state concurrently with the game thread reading it. That's a data race on `ControlMap`, and it's rolled on every click, which is why the freezes look random and cluster around trigger interaction.

## Fix

Queue the toggle through the SKSE task interface so `ToggleControls` only ever runs on the game thread — the same `SKSE::GetTaskInterface()->AddTask(...)` pattern already used elsewhere in the codebase (API.cpp, Core.cpp, InputHandler.cpp). `AddTask` preserves FIFO order, so rapid mask→unmask sequences from fast clicks still apply in the order they were issued.

One file, no behavior change beyond the thread hop:

```
src/PrismaUI/PrismaVR_Bridge.h | 30 +++++++++++++++++------------
1 file changed, 18 insertions(+), 12 deletions(-)
```

Flatscreen is unaffected (these helpers are only driven by the VR input path).

## Validation

Built clean against CommonLibVR; deployed to a full VR load order and confirmed by alpha testers that the panel freezes stopped.
