### PR TITLE
Added a JavaScript API, TypeScript type definition, and revised events

### DIFF
--- a/assets/misc/PrismaUI_API.d.ts
+++ b/assets/misc/PrismaUI_API.d.ts
@@ -1,0 +1,92 @@
+/*
+ * For modders: TypeScript definitions for the `window.prismaUi` object available inside a PrismaUI view.
+ * Reference it from your UI project (e.g. `/// <reference path="PrismaUI_API.d.ts" />` or via tsconfig
+ * "include") to get typing and autocompletion. This is the JavaScript-side counterpart to PrismaUI_API.h.
+ *
+ * PrismaUI injects `window.prismaUi` before your page scripts run, so it is safe to reference on load.
+ */
+
+/** RE::ControlMap::UserEventMapping */
+interface PrismaUiControlMapping {
+    eventID: string;
+    inputKey: number;
+    modifier: number;
+    remappable: boolean;
+    linked: boolean;
+}
+
+/** Bindings grouped by input device within a single context */
+interface PrismaUiControlContextDevices {
+    keyboard?: PrismaUiControlMapping[]
+    mouse?: PrismaUiControlMapping[]
+    gamepad?: PrismaUiControlMapping[]
+    /** Non-standard slots (flat virtual keyboard, VR controllers), keyed by device index (e.g., 3) */
+    others: { [deviceIndex: number]: PrismaUiControlMapping[] }
+}
+
+type PrismaUiControlContextName = "Gameplay" | "MenuMode" | "Console" | "ItemMenu" | "Inventory" | "DebugText" | "Favorites" | "Map" | "Stats" | "Cursor" | "Book" | "DebugOverlay" | "Journal" | "TFCMode" | "MapDebug" | "Lockpicking" | "Favor/Marketplace" | "Marketplace";
+
+/** One input context (Gameplay, MenuMode, Inventory, etc.) and its per-device bindings */
+interface PrismaUiControlContext {
+    /** Context index in the engine's control map */
+    index: number;
+    /** Canonical context name, e.g. "Gameplay", "MenuMode", "Inventory" */
+    name: string;
+    devices: PrismaUiControlContextDevices;
+}
+
+/** Snapshot of the game's key bindings (RE::ControlMap). For window.prismaUi.controls.map. */
+interface PrismaUiControlMap {
+    /** Gamepad glyph set: 0 = Xbox/DirectX, 1 = PlayStation/Orbis */
+    gamePadType: number;
+    contexts: PrismaUiControlContext[];
+}
+
+/** detail of the gamepadbuttondown and gamepadbuttonup events */
+interface PrismaUiGamepadButtonEventDetail {
+    /** Button index in the W3C Standard Gamepad mapping, matching navigator.getGamepads() */
+    w3cButtonIndex: number;
+    /** Raw Skyrim gamepad button ID code */
+    skyrimIdCode: number;
+    /** Menu role of the button in MenuMode: "accept", "cancel", or "" when it maps to neither */
+    action: "accept" | "cancel" | "";
+}
+
+/** Events dispatched on `window.prismaUi.controls` */
+interface PrismaUiControlsEventMap {
+    /** Fired when a gamepad button is pressed */
+    gamepadbuttondown: CustomEvent<PrismaUiGamepadButtonEventDetail>
+    /** Fired when a gamepad button is released */
+    gamepadbuttonup: CustomEvent<PrismaUiGamepadButtonEventDetail>
+    /** Fired when the control map is refreshed from SKSE (e.g., on load, on focus, or after calling controls.refresh()) */
+    refreshcomplete: CustomEvent<PrismaUiControlMap>
+}
+
+/**
+ * Input subsystem of PrismaUI, exposed as `window.prismaUi.controls`. It is an EventTarget, so use
+ * `window.prismaUi.controls.addEventListener(...)` to observe the events in PrismaUiControlsEventMap.
+ */
+interface PrismaUiControls extends EventTarget {
+    /** Latest key-binding snapshot. Populated on load. */
+    map?: PrismaUiControlMap
+
+    /** Requests a fresh map snapshot from the game (in case the player remaps controls) */
+    refresh(): void
+
+    /** Gets the Skyrim event ID using the W3C Standard Gamepad button index */
+    getEventIdByButtonIndex(w3cButtonIndex: number, contextName?: PrismaUiControlContextName): string | null
+
+    addEventListener<K extends keyof PrismaUiControlsEventMap>(type: K, listener: (this: PrismaUiControls, ev: PrismaUiControlsEventMap[K]) => unknown, options?: boolean | AddEventListenerOptions): void
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void
+    removeEventListener<K extends keyof PrismaUiControlsEventMap>(type: K, listener: (this: PrismaUiControls, ev: PrismaUiControlsEventMap[K]) => unknown, options?: boolean | EventListenerOptions): void
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void
+}
+
+/** The PrismaUI JavaScript namespace, exposed as `window.prismaUi`. */
+interface PrismaUi {
+    controls: PrismaUiControls
+}
+
+interface Window {
+    prismaUi: PrismaUi
+}

--- a/assets/misc/PrismaUI_API.d.ts
+++ b/assets/misc/PrismaUI_API.d.ts
@@ -70,7 +70,7 @@ interface PrismaUiControls extends EventTarget {
     /** Latest key-binding snapshot. Populated on load. */
     map?: PrismaUiControlMap
 
-    /** Requests a fresh map snapshot from the game (in case the player remaps controls) */
+    /** Requests a fresh map snapshot from the game (in case the player remaps controls). Keybindings should refresh automatically. */
     refresh(): void
 
     /** Gets the Skyrim event ID using the W3C Standard Gamepad button index */

--- a/src/PrismaUI/Communication.cpp
+++ b/src/PrismaUI/Communication.cpp
@@ -1,11 +1,47 @@
 ﻿#include "Communication.h"
 
 #include "Core.h"
+#include "GamepadInputHandler.h"
 #include "ViewManager.h"
 
 namespace PrismaUI::Communication {
     using namespace Core;
     using namespace ViewManager;
+
+    const char* PrismaObjectEnsureExpression() {
+        static const std::string kExpr =
+            std::string(R"js(
+((window.prismaUi && typeof window.prismaUi == "object")
+    ? window.prismaUi
+    : (function () {
+        const prismaUi = window.prismaUi || (window.prismaUi = {});
+        const controls = new EventTarget();
+        const w3cToSkyrim = )js") +
+            GamepadInputHandler::GetW3cToSkyrimJson() +
+            R"js(;
+        controls.refresh = function () { return window.__prismaRefreshControlMap("")/*Argument is unused.*/ };
+        controls.getEventIdByButtonIndex = function (w3cButtonIndex, contextName = "Gameplay") {
+            const code = w3cToSkyrim[w3cButtonIndex];
+            if (code == null) { throw new Error("code was undefined for w3cButtonIndex " + w3cButtonIndex); }
+            if (!controls.map) { throw new Error("controls.map was not set."); }
+            const context = controls.map.contexts.find(c => c.name === contextName);
+            if (context == null) { throw new Error("context was null for contextName " + contextName); }
+            const gamepad = context.devices.gamepad;
+            if (gamepad == null) { throw new Error("gamepad was null for context " + contextName); }
+            const mapping = gamepad.find(m => m.inputKey == code);
+            return mapping != null ? mapping.eventID : null;
+        };
+        prismaUi.controls = controls;
+        return prismaUi;
+    })())
+)js";
+        return kExpr.c_str();
+    }
+
+    const char* PrismaControlsEnsureExpression() {
+        static const std::string kExpr = std::string(PrismaObjectEnsureExpression()) + ".controls";
+        return kExpr.c_str();
+    }
 
     void Invoke(const Core::PrismaViewId& viewId, const String& script, std::function<void(std::string)> callback) {
         std::shared_ptr<PrismaView> viewData = nullptr;

--- a/src/PrismaUI/Communication.cpp
+++ b/src/PrismaUI/Communication.cpp
@@ -8,7 +8,7 @@ namespace PrismaUI::Communication {
     using namespace Core;
     using namespace ViewManager;
 
-    const char* PrismaObjectEnsureExpression() {
+    const std::string& PrismaObjectEnsureExpression() {
         static const std::string kExpr =
             std::string(R"js(
 ((window.prismaUi && typeof window.prismaUi == "object")
@@ -35,12 +35,12 @@ namespace PrismaUI::Communication {
         return prismaUi;
     })())
 )js";
-        return kExpr.c_str();
+        return kExpr;
     }
 
-    const char* PrismaControlsEnsureExpression() {
-        static const std::string kExpr = std::string(PrismaObjectEnsureExpression()) + ".controls";
-        return kExpr.c_str();
+    const std::string& PrismaControlsEnsureExpression() {
+        static const std::string kExpr = PrismaObjectEnsureExpression() + ".controls";
+        return kExpr;
     }
 
     void Invoke(const Core::PrismaViewId& viewId, const String& script, std::function<void(std::string)> callback) {

--- a/src/PrismaUI/Communication.h
+++ b/src/PrismaUI/Communication.h
@@ -25,6 +25,11 @@ namespace PrismaUI::Communication {
                                  const JSValueRef arguments[], JSValueRef* exception);
     void RegisterJSListener(const Core::PrismaViewId& viewId, const std::string& name, Core::SimpleJSCallback callback);
     void InteropCall(const Core::PrismaViewId& viewId, const std::string& functionName, const std::string& argument);
+
+    // Idempotent JS expressions. Each builds a new object or returns a previously built object.
+    const char* PrismaObjectEnsureExpression();    // Ensures and returns window.prismaUi
+    const char* PrismaControlsEnsureExpression();  // Ensures and returns window.prismaUi.controls
+
     JSValueRef JSCallbackDispatcher(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
                                     size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception);
 }

--- a/src/PrismaUI/Communication.h
+++ b/src/PrismaUI/Communication.h
@@ -27,8 +27,8 @@ namespace PrismaUI::Communication {
     void InteropCall(const Core::PrismaViewId& viewId, const std::string& functionName, const std::string& argument);
 
     // Idempotent JS expressions. Each builds a new object or returns a previously built object.
-    const char* PrismaObjectEnsureExpression();    // Ensures and returns window.prismaUi
-    const char* PrismaControlsEnsureExpression();  // Ensures and returns window.prismaUi.controls
+    const std::string& PrismaObjectEnsureExpression();    // Ensures and returns window.prismaUi
+    const std::string& PrismaControlsEnsureExpression();  // Ensures and returns window.prismaUi.controls
 
     JSValueRef JSCallbackDispatcher(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
                                     size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception);

--- a/src/PrismaUI/ControlMapBridge.cpp
+++ b/src/PrismaUI/ControlMapBridge.cpp
@@ -43,12 +43,9 @@ namespace PrismaUI::ControlMapBridge {
             out += '"';
         }
 
-        // JSON key for a standard input device slot; throws if called with an unexpected index.
+        // JSON key for a standard input device slot
         std::string GetDeviceKey(std::size_t index) {
-            return index == 0   ? "keyboard"
-                   : index == 1 ? "mouse"
-                   : index == 2 ? "gamepad"
-                                : throw std::runtime_error("GetDeviceKey: unhandled index " + std::to_string(index));
+            return index == 0 ? "keyboard" : index == 1 ? "mouse" : index == 2 ? "gamepad" : "unknown";
         }
 
         // Canonical name for an input context index
@@ -71,7 +68,7 @@ namespace PrismaUI::ControlMapBridge {
                    : index == 15 ? "Lockpicking"
                    : index == 16 ? "Favor/Marketplace"  // Favor on 1.5, Marketplace on 1.6
                    : index == 17 ? "Favor"
-                                 : throw std::runtime_error("GetContextName: unhandled index " + std::to_string(index));
+                                 : "Unknown";
         }
 
         std::string BuildJson() {

--- a/src/PrismaUI/ControlMapBridge.cpp
+++ b/src/PrismaUI/ControlMapBridge.cpp
@@ -1,0 +1,204 @@
+#include "ControlMapBridge.h"
+
+#include <cstdio>
+#include <mutex>
+#include <set>
+#include <stdexcept>
+#include <vector>
+
+#include "Communication.h"
+#include "Core.h"
+
+namespace PrismaUI::ControlMapBridge {
+    namespace {
+        std::mutex g_pendingMutex;
+        std::set<Core::PrismaViewId> g_pending;  // Views awaiting a control-map push. Drained per frame.
+
+        // Appends a JSON-quoted, escaped string. Context and device labels are fixed ASCII, but event IDs come
+        // from the control map (including mod-registered ones), so escaping is required for valid JSON.
+        void AppendJsonString(std::string& out, const char* s) {
+            out += '"';
+            if (s) {
+                for (const char* p = s; *p; ++p) {
+                    const unsigned char c = static_cast<unsigned char>(*p);
+                    const char* escape = c == '"'    ? "\\\""
+                                         : c == '\\' ? "\\\\"
+                                         : c == '\b' ? "\\b"
+                                         : c == '\f' ? "\\f"
+                                         : c == '\n' ? "\\n"
+                                         : c == '\r' ? "\\r"
+                                         : c == '\t' ? "\\t"
+                                                     : nullptr;
+                    if (escape) {
+                        out += escape;
+                    } else if (c < 0x20) {
+                        char buf[7];
+                        std::snprintf(buf, sizeof(buf), "\\u%04x", c);
+                        out += buf;
+                    } else {
+                        out += static_cast<char>(c);
+                    }
+                }
+            }
+            out += '"';
+        }
+
+        // JSON key for a standard input device slot; throws if called with an unexpected index.
+        std::string GetDeviceKey(std::size_t index) {
+            return index == 0   ? "keyboard"
+                   : index == 1 ? "mouse"
+                   : index == 2 ? "gamepad"
+                                : throw std::runtime_error("GetDeviceKey: unhandled index " + std::to_string(index));
+        }
+
+        // Canonical name for an input context index
+        const char* GetContextName(std::size_t index) {
+            return index == 0    ? "Gameplay"
+                   : index == 1  ? "MenuMode"
+                   : index == 2  ? "Console"
+                   : index == 3  ? "ItemMenu"
+                   : index == 4  ? "Inventory"
+                   : index == 5  ? "DebugText"
+                   : index == 6  ? "Favorites"
+                   : index == 7  ? "Map"
+                   : index == 8  ? "Stats"
+                   : index == 9  ? "Cursor"
+                   : index == 10 ? "Book"
+                   : index == 11 ? "DebugOverlay"
+                   : index == 12 ? "Journal"
+                   : index == 13 ? "TFCMode"
+                   : index == 14 ? "MapDebug"
+                   : index == 15 ? "Lockpicking"
+                   : index == 16 ? "Favor/Marketplace"  // Favor on 1.5, Marketplace on 1.6
+                   : index == 17 ? "Favor"
+                                 : throw std::runtime_error("GetContextName: unhandled index " + std::to_string(index));
+        }
+
+        std::string BuildJson() {
+            auto* cm = RE::ControlMap::GetSingleton();
+            if (!cm) {
+                return "null";
+            }
+
+            std::string out;
+            out.reserve(16384);
+            out += "{\"gamePadType\":";
+            out += std::to_string(static_cast<int>(cm->GetGamePadType()));
+            out += ",\"contexts\":[";
+
+            // Bound device iteration to the running runtime's device count, and iterate the contexts that
+            // exist on every runtime. INPUT_CONTEXT_IDS::kTotal (17) is valid across 1.5 and 1.6.
+            // But 1.6 has extra kMarketplace value. See GetContextName.
+            const std::size_t deviceCount = RE::ControlMap::InputContext::GetNumDeviceMappings();
+            constexpr std::size_t contextCount = RE::UserEvents::INPUT_CONTEXT_IDS::kTotal;
+
+            bool firstContext = true;
+            for (std::size_t ctx = 0; ctx < contextCount; ++ctx) {
+                RE::ControlMap::InputContext* inputContext = cm->controlMap[ctx];
+                if (!inputContext) {
+                    continue;
+                }
+
+                if (!firstContext) {
+                    out += ',';
+                }
+                firstContext = false;
+
+                out += "{\"index\":";
+                out += std::to_string(ctx);
+                out += ",\"name\":";
+                AppendJsonString(out, GetContextName(ctx));
+                out += ",\"devices\":{";
+
+                // Emits one device slot as `"<key>":[<mappings>]` into `out`.
+                const auto appendDevice = [&](const std::string& key, std::size_t dev) {
+                    AppendJsonString(out, key.c_str());
+                    out += ":[";
+                    const auto& mappings = inputContext->deviceMappings[dev];
+                    for (std::uint32_t i = 0; i < mappings.size(); ++i) {
+                        const auto& mapping = mappings[i];
+                        if (i != 0) {
+                            out += ',';
+                        }
+                        out += "{\"eventID\":";
+                        AppendJsonString(out, mapping.eventID.c_str());
+                        out += ",\"inputKey\":";
+                        out += std::to_string(mapping.inputKey);
+                        out += ",\"modifier\":";
+                        out += std::to_string(mapping.modifier);
+                        out += ",\"remappable\":";
+                        out += mapping.remappable ? "true" : "false";
+                        out += ",\"linked\":";
+                        out += mapping.linked ? "true" : "false";
+                        out += '}';
+                    }
+                    out += ']';
+                };
+
+                // keyboard (0), mouse (1), gamepad (2) are first.
+                // The rest are saved in `devices.others`.
+                bool anyStandard = false;
+                for (std::size_t dev = 0; dev < deviceCount && dev < 3; ++dev) {
+                    if (anyStandard) {
+                        out += ',';
+                    }
+                    anyStandard = true;
+                    appendDevice(GetDeviceKey(dev), dev);
+                }
+
+                if (anyStandard) {
+                    out += ',';
+                }
+                out += "\"others\":{";
+                bool firstOther = true;
+                for (std::size_t dev = 3; dev < deviceCount; ++dev) {
+                    if (!firstOther) {
+                        out += ',';
+                    }
+                    firstOther = false;
+                    // Below, JSON requires string keys, but JavaScript will still coerce integers into strings when
+                    // used like devices.others[3].
+                    appendDevice(std::to_string(dev), dev);
+                }
+                out += "}}}";  // close `others`, `devices`, and `context`
+            }
+
+            out += "]}";
+            return out;
+        }
+    }
+
+    void RequestRefresh(Core::PrismaViewId viewId) {
+        std::lock_guard lock(g_pendingMutex);
+        g_pending.insert(viewId);
+    }
+
+    void ProcessPendingRefreshes() {
+        // Check for pending refreshes.
+        std::vector<Core::PrismaViewId> pending;
+        {
+            std::lock_guard lock(g_pendingMutex);
+            if (g_pending.empty()) {
+                return;
+            }
+            pending.assign(g_pending.begin(), g_pending.end());
+            g_pending.clear();
+        }
+
+        // Read ControlMap here on the render thread.
+        const std::string json = BuildJson();
+
+        std::string script;
+        script.reserve(json.size() + 256);
+        script += "(function(c){c.map=";
+        script += json;
+        script += ";c.dispatchEvent(new CustomEvent(\"refreshcomplete\",{detail:c.map}));})(";
+        script += Communication::PrismaControlsEnsureExpression();
+        script += ");";
+
+        // Send the JavaScript string to each view via Invoke.
+        for (const auto viewId : pending) {
+            Communication::Invoke(viewId, script.c_str());
+        }
+    }
+}

--- a/src/PrismaUI/ControlMapBridge.h
+++ b/src/PrismaUI/ControlMapBridge.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace PrismaUI::Core {
+    typedef uint64_t PrismaViewId;
+}
+
+// Exposes RE::ControlMap (the game's keybinding registry) to a view's JavaScript
+namespace PrismaUI::ControlMapBridge {
+    // Queues a view to receive a control snapshot
+    void RequestRefresh(Core::PrismaViewId viewId);
+
+    // Drains queued refresh requests and sends the updated control map to each view's window.prismaUi object
+    void ProcessPendingRefreshes();
+}

--- a/src/PrismaUI/Core.cpp
+++ b/src/PrismaUI/Core.cpp
@@ -3,6 +3,7 @@
 #include <eh.h>  // For _set_se_translator
 
 #include "Communication.h"
+#include "ControlMapBridge.h"
 #include "InputHandler.h"
 #include "Inspector.h"
 #include "Listeners.h"
@@ -303,6 +304,9 @@ namespace PrismaUI::Core {
 
         // Process pending operations for all views
         ViewOperationQueue::ProcessAllViewOperations();
+
+        // Read ControlMap here on the render thread and push any queued snapshots to JavaScript
+        ControlMapBridge::ProcessPendingRefreshes();
 
         auto ultralightFuture = ultralightThread.submit([dev = d3dDevice, ctx = d3dContext, hwnd = hWnd]() {
             // Enable SEH to C++ exception translation for this thread (only needs to be

--- a/src/PrismaUI/GamepadInputHandler.cpp
+++ b/src/PrismaUI/GamepadInputHandler.cpp
@@ -112,7 +112,7 @@ namespace PrismaUI::GamepadInputHandler {
                 }
             }
 
-            std::string script = std::string(Communication::PrismaControlsEnsureExpression()) +
+            std::string script = Communication::PrismaControlsEnsureExpression() +
                                  ".dispatchEvent(new CustomEvent(\"" + eventName +
                                  "\", {detail: {w3cButtonIndex: " + std::to_string(w3cButtonIndex) +
                                  ", skyrimIdCode: " + std::to_string(skyrimIDCode) + ", action: \"" + action + "\"}}))";

--- a/src/PrismaUI/GamepadInputHandler.cpp
+++ b/src/PrismaUI/GamepadInputHandler.cpp
@@ -35,8 +35,8 @@ namespace PrismaUI::GamepadInputHandler {
         constexpr uint32_t GAMEPAD_AXIS_COUNT = 4;     // W3C standard gamepad with left and right X and Y axes
         constexpr uint32_t GAMEPAD_BUTTON_COUNT = 17;  // W3C standard gamepad with 17 buttons
 
-        // A JavaScript event (prismagamepadbuttondown or prismagamepadbuttonup) to dispatch into a view.
-        // It queued right after the button's state change so it runs on the Ultralight thread
+        // A JavaScript event (gamepadbuttondown or gamepadbuttonup on window.prismaUi.controls) to dispatch into a
+        // view. It is queued right after the button's state change so it runs on the Ultralight thread
         // only once that state is applied, letting a handler read the new state via navigator.getGamepads().
         struct JsButtonDispatch {
             Core::PrismaViewId viewId;
@@ -85,8 +85,8 @@ namespace PrismaUI::GamepadInputHandler {
         }
 
         // Resolves the menu role of the button via the control map and builds a named CustomEvent
-        // (detail: { w3cButtonIndex: number, skyrimIdCode: number, action: string }) dispatched on window.
-        // eventName is "prismagamepadbuttondown" on a press or "prismagamepadbuttonup" on a release.
+        // (detail: { w3cButtonIndex: number, skyrimIdCode: number, action: string }) dispatched on the
+        // window.prismaUi.controls. eventName is "gamepadbuttondown" on a press or "gamepadbuttonup" on a release.
         // Returns nullopt when no view is focused. The caller queues the result behind the button's state
         // change so the event fires only after navigator.getGamepads() reflects it.
         std::optional<JsButtonDispatch> BuildButtonDispatch(const char* eventName, uint32_t w3cButtonIndex,
@@ -112,10 +112,10 @@ namespace PrismaUI::GamepadInputHandler {
                 }
             }
 
-            std::string script = std::string("window.dispatchEvent(new CustomEvent(\"") + eventName +
+            std::string script = std::string(Communication::PrismaControlsEnsureExpression()) +
+                                 ".dispatchEvent(new CustomEvent(\"" + eventName +
                                  "\", {detail: {w3cButtonIndex: " + std::to_string(w3cButtonIndex) +
-                                 ", skyrimIdCode: " + std::to_string(skyrimIDCode) + ", action: \"" + action +
-                                 "\"}}))";
+                                 ", skyrimIdCode: " + std::to_string(skyrimIDCode) + ", action: \"" + action + "\"}}))";
             return JsButtonDispatch{viewId, std::move(script)};
         }
 
@@ -137,9 +137,9 @@ namespace PrismaUI::GamepadInputHandler {
             // which we don't want to do while holding g_gamepadQueueMutex.
             std::optional<JsButtonDispatch> dispatch;
             if (buttonEvent->IsDown()) {
-                dispatch = BuildButtonDispatch("prismagamepadbuttondown", w3cButtonIndex, buttonIDCode);
+                dispatch = BuildButtonDispatch("gamepadbuttondown", w3cButtonIndex, buttonIDCode);
             } else if (buttonEvent->IsUp()) {
-                dispatch = BuildButtonDispatch("prismagamepadbuttonup", w3cButtonIndex, buttonIDCode);
+                dispatch = BuildButtonDispatch("gamepadbuttonup", w3cButtonIndex, buttonIDCode);
             }
 
             // A trigger ranges from 0 to 1 (float); a digital button returns 0 or 1.
@@ -296,6 +296,51 @@ namespace PrismaUI::GamepadInputHandler {
                 },
                 event);
         }
+    }
+
+    const std::string& GetW3cToSkyrimJson() {
+        // Built once from SkyrimIDCodeToW3CIndex (the single source of truth for the W3C<->Skyrim mapping).
+        // Keys are W3C button indices, values are Skyrim gamepad button codes (BSWin32GamepadDevice::Key).
+        static const std::string json = [] {
+            using Key = RE::BSWin32GamepadDevice::Key;
+            constexpr uint32_t codes[] = {
+                Key::kA,
+                Key::kB,
+                Key::kX,
+                Key::kY,
+                Key::kLeftShoulder,
+                Key::kRightShoulder,
+                Key::kLeftTrigger,
+                Key::kRightTrigger,
+                Key::kBack,
+                Key::kStart,
+                Key::kLeftThumb,
+                Key::kRightThumb,
+                Key::kUp,
+                Key::kDown,
+                Key::kLeft,
+                Key::kRight,
+            };
+            std::string s = "{";
+            bool first = true;
+            for (const uint32_t code : codes) {
+                const int w3c = SkyrimIDCodeToW3CIndex(code);
+                if (w3c < 0) {
+                    continue;
+                }
+                if (!first) {
+                    s += ',';
+                }
+                first = false;
+                s += '"';
+                s += std::to_string(w3c);
+                s += "\":";
+                s += std::to_string(code);
+            }
+            s += '}';
+            return s;
+        }();
+        return json;
     }
 
     void ResetButtonValues() {

--- a/src/PrismaUI/GamepadInputHandler.h
+++ b/src/PrismaUI/GamepadInputHandler.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 class SingleThreadExecutor;
 
 namespace PrismaUI::GamepadInputHandler {
@@ -20,4 +22,7 @@ namespace PrismaUI::GamepadInputHandler {
 
     // Removes the sink and clears queued state.
     void Shutdown();
+
+    // JSON object mapping W3C Standard Gamepad button index to Skyrim gamepad button code
+    const std::string& GetW3cToSkyrimJson();
 }

--- a/src/PrismaUI/Listeners.cpp
+++ b/src/PrismaUI/Listeners.cpp
@@ -53,7 +53,7 @@ namespace PrismaUI::Listeners {
         if (is_main_frame) {
             logger::info("View [{}]: LoadListener: Window object ready.", viewId_);
             // Create the window.prismaUi object before the page's own scripts run.
-            Communication::InvokeFromUltralightThread(viewId_, Communication::PrismaObjectEnsureExpression());
+            Communication::InvokeFromUltralightThread(viewId_, Communication::PrismaObjectEnsureExpression().c_str());
         }
     }
 

--- a/src/PrismaUI/Listeners.cpp
+++ b/src/PrismaUI/Listeners.cpp
@@ -1,6 +1,7 @@
 ﻿#include "Listeners.h"
 
 #include "Communication.h"
+#include "ControlMapBridge.h"
 #include "Core.h"
 #include "PrismaUI_API.h"
 
@@ -51,6 +52,8 @@ namespace PrismaUI::Listeners {
                                              const String& /*url*/) {
         if (is_main_frame) {
             logger::info("View [{}]: LoadListener: Window object ready.", viewId_);
+            // Create the window.prismaUi object before the page's own scripts run.
+            Communication::InvokeFromUltralightThread(viewId_, Communication::PrismaObjectEnsureExpression());
         }
     }
 
@@ -58,6 +61,9 @@ namespace PrismaUI::Listeners {
                                     const String& /*url*/) {
         if (is_main_frame) {
             logger::info("View [{}]: LoadListener: DOM ready.", viewId_);
+
+            // Request updated keybindings.
+            ControlMapBridge::RequestRefresh(viewId_);
 
             ultralightThread.submit([id = viewId_] {
                 std::shared_lock lock(viewsMutex);

--- a/src/PrismaUI/ViewManager.cpp
+++ b/src/PrismaUI/ViewManager.cpp
@@ -1,5 +1,7 @@
 ﻿#include "ViewManager.h"
 
+#include "Communication.h"
+#include "ControlMapBridge.h"
 #include "Core.h"
 #include "InputHandler.h"
 #include "Inspector.h"
@@ -61,6 +63,11 @@ namespace PrismaUI::ViewManager {
         logger::info(
             "View [{}] creation requested for path: {} with order <{}>. Actual view will be created by UI thread.",
             newViewId, fileUrl, viewData->order);
+
+        // Internal binding behind the public window.prismaUi.controls.refresh() helper.
+        // The callback system can only bind global functions, not functions belonging to an object.
+        Communication::RegisterJSListener(newViewId, "__prismaRefreshControlMap",
+                                          [newViewId](std::string) { ControlMapBridge::RequestRefresh(newViewId); });
 
         return newViewId;
     }
@@ -247,6 +254,9 @@ namespace PrismaUI::ViewManager {
             // Focus this view
             viewData->ultralightView->Focus();
             PrismaUI::InputHandler::EnableInputCapture(viewId);
+
+            // Refresh the control-map snapshot so the view has the latest keybindings.
+            ControlMapBridge::RequestRefresh(viewId);
 
             if (!disableFocusMenu && !PrismaVR::IsVRActive()) {
                 FocusMenu::Open();  // Flatscreen cursor — in VR, PrismaVR laser handles interaction
@@ -622,8 +632,9 @@ namespace PrismaUI::ViewManager {
         }
     }
 
-    void RegisterConsoleCallback(const Core::PrismaViewId& viewId,
-                                 std::function<void(Core::PrismaViewId, PRISMA_UI_API::ConsoleMessageLevel, const std::string&)> callback) {
+    void RegisterConsoleCallback(
+        const Core::PrismaViewId& viewId,
+        std::function<void(Core::PrismaViewId, PRISMA_UI_API::ConsoleMessageLevel, const std::string&)> callback) {
         std::unique_lock lock(viewsMutex);
         auto it = views.find(viewId);
         if (it != views.end() && it->second) {


### PR DESCRIPTION
The new JavaScript API and TypeScript definitions can be found in assets/misc/PrismaUI_API.d.ts.

With that API, prismaUi.controls has three events: gamepadbuttondown, gamepadbuttonup, and refreshcomplete.

The new API helps with keybinding discovery. It also only consumes window.prismaUi.controls, leaving the rest of the window.prismaUi object uncluttered and open to future development.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new browser-side Prisma UI controls API with typed access to control snapshots, refresh support, and gamepad button event handling.
  * Gamepad button interactions now emit updated control events and include clearer button-to-action mapping data.

* **Bug Fixes**
  * Control bindings now refresh automatically when a view loads, gains focus, or requests an update, helping keep on-screen controls in sync.
  * Improved reliability of control-map updates during rendering and page initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->